### PR TITLE
Linux build script uses wrong path depth

### DIFF
--- a/docs/release/buildLinuxVM
+++ b/docs/release/buildLinuxVM
@@ -19,7 +19,7 @@
 #
 #   Do:
 
-export SELF_WORKING_DIR=${PWD}/.. 
+export SELF_WORKING_DIR=${PWD}/../..
 echo Setting paths: SELF_WORKING_DIR = $SELF_WORKING_DIR
 
 export PATH=$PATH:$SELF_WORKING_DIR/bin/linux


### PR DESCRIPTION
The script for building on Linux has an incorrect PATH depth due to being moved to a new location that has one more level of directory nesting. This commit fixes that. Tested on an Ubuntu build machine.
