### PR TITLE
Fix compile error in oop.cpp

### DIFF
--- a/vm/src/any/objects/oop.cpp
+++ b/vm/src/any/objects/oop.cpp
@@ -302,7 +302,7 @@ mirrorOop oopClass::as_mirror(bool mustAllocate) {
     oop CONC3(set_,flagName,_prim)(oop rcvr, oop flag) {                      \
       breakpoint();                                                           \
       Unused(rcvr); Unused(flag);                                             \
-      if (! (checkNewValue)) {                                                \
+      if (! (checkNewValue))                                                  \
         return ErrorCodes::vmString_prim_error(BADTYPEERROR);                 \
       oop oldValue = getCurrentValue;                                         \
       setNewValue;                                                            \


### PR DESCRIPTION
On Linux I get a compile error in oop.cpp. Attached patch fixes it. I'm not sure why it hasn't been hit before since the file doesn't seem to have been touched for 6 months. Maybe a debug vs release thing?
