### PR TITLE
Allow remote desktop sharing to work again on Linux

### DIFF
--- a/objects/ui2/canvas.self
+++ b/objects/ui2/canvas.self
@@ -1,7 +1,7 @@
  '$Revision: 30.17 $'
  '
-Copyright 1992-2012 AUTHORS.
-See the LICENSE file for license information.
+Copyright 1992-2011 AUTHORS.
+See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
 
 
@@ -2353,9 +2353,6 @@ the pixmapCache some day.
              n.
             | 
             n: displayName.
-
-            "For Linux, default to local display"
-            host osName = 'linux' ifTrue: [n: ''].
 
             [ | err |
               err: [|:exit|

--- a/objects/ui2/worldMorph.self
+++ b/objects/ui2/worldMorph.self
@@ -1,7 +1,7 @@
  '$Revision: 30.30 $'
  '
-Copyright 1992-2012 AUTHORS.
-See the LICENSE file for license information.
+Copyright 1992-2011 AUTHORS.
+See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
 
 
@@ -2119,7 +2119,7 @@ on the default display.\x7fModuleInfo: Module: worldMorph InitialContents: Follo
                 oldBounds: (3@24 max: wc position) ## wc size.
                 oldOffset: wc offset.
                 releaseParts.
-                addWindowOnDisplay: (platformSpecificNameFor: wc displayName) Bounds: oldBounds.
+                addWindowOnDisplay: (platformSpecificNameFor: wc originalDisplayName) Bounds: oldBounds.
                 winCanvases first offset: oldOffset.  "set scroll offset of new canvas"
 
                 morphsDo: [| :m |


### PR DESCRIPTION
Git commit 882d8cf2 fixed a problem where restarting a snapshot that
had open worlds would fail on Linux due to using the fully qualified
display name. Unfortunately it broke support for sharing worlds on
other displays - they would always open on the local display.

The fix backs out that change so that remote displays work and fixes
the original issue by using the default display name.

This can be tested by starting an additional Xserver like Xnest:

```
$ Xnest -ac :1 &
```

Then from within Self on the local display grab a 'Share window with' Morph from the factory onto the desktop. Enter '127.0.0.1:1.0' and press 'share window with'. The Xnest will now show a Self desktop and you can see the other user.

Prior to this patch the desktop would always spawn in a new window on the local display regardless of the display name used.

Saving the snapshot, exiting, then restarting correctly opens the windows on the local display. 
