### PR TITLE
Prevent error when renaming outliner titles

### DIFF
--- a/objects/ui2/outliner/generalCategoryModel.self
+++ b/objects/ui2/outliner/generalCategoryModel.self
@@ -1,7 +1,7 @@
  '$Revision: 30.15 $'
  '
-Copyright 1992-2012 AUTHORS.
-See the LICENSE file for license information.
+Copyright 1992-2011 AUTHORS.
+See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
 
 
@@ -715,6 +715,16 @@ I am also immutable.\x7fModuleInfo: Creator: globals generalCategoryModel parent
             isForEditingNew && [newName isEmpty] ifTrue: [
              ^ myOutliner cancelChangingNameEditor: rr editor Event: rr event
             ].
+
+            categoryList isEmpty ifTrue: [
+              referrent: categoryReferrentProto
+                    copyForMirror: mirror
+                     CategoryList: vector copy.
+              resend.unprotectedFinishChangingName: rr.
+              safelyDo: [ myOutliner beFlexibleHorizontally update ].
+              ^ self
+            ].
+
             i: categoryList size pred.
             ocat: categoryList last.
 


### PR DESCRIPTION
This is an attempt to resolve #2. The walkback occurs due to
the categoryList in the pluggable outliner being empty. The
existing code attempts to get the last element and the index of
it and fails.

This fix first checks if the categoryList is empty and then stops
the editing process. The walkback no longer occurs. Unforunately
the title of the object doesn't change either. It immediately
goes back to what it was originally.
