### PR TITLE
Force 10.6 compat SDK

### DIFF
--- a/vm/cmake/mac_osx.cmake
+++ b/vm/cmake/mac_osx.cmake
@@ -43,6 +43,22 @@ if(NOT CONFIG_HAS_BEEN_RUN_BEFORE)
   set(CMAKE_OSX_DEPLOYMENT_TARGET "10.6" CACHE STRING
     "Minimum OS X version to target for deployment (at runtime); newer APIs weak linked. Set to empty string for default value."
     FORCE)
+  # see if we can get a matching SDK
+  foreach(sdk "macosx10.8" "macosx10.7" "macosx10.6")
+    execute_process(
+    COMMAND xcodebuild -version -sdk "${sdk}"
+    OUTPUT_VARIABLE _sdkpath
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    ERROR_VARIABLE _stderr
+    RESULT_VARIABLE _failed)
+    if(NOT _failed)
+      set(CMAKE_OSX_SYSROOT "${sdk}" CACHE STRING
+        "The product will be built against the headers and libraries located inside the indicated SDK."
+        FORCE
+      )
+      break()
+    endif()
+  endforeach()
 endif()
 
 year(YEAR)


### PR DESCRIPTION
Force to use a 10.6 compat SDK (10.9 seems no longer feasible).

This addresses #20.
