### PR TITLE
Added "New Object" to desktop menu.

### DIFF
--- a/objects/ui2/worldMorph.self
+++ b/objects/ui2/worldMorph.self
@@ -368,6 +368,14 @@ gets stuck.
 
             m addButton:
                 ( ( ui2Button copy
+                   scriptBlock: [event sourceHand attach:
+                                   selfObjectModel newOutlinerFor: (reflect: ())
+                                                          InWorld: event sourceHand world] )
+                   label: 'New Object' )
+            ToGroup: 'top'.
+
+            m addButton:
+                ( ( ui2Button copy
                    scriptBlock: [shell save] )
                    label: 'Save snapshot')
             ToGroup: 'memory'.


### PR DESCRIPTION
Every video I watch of self being demonstrated, old or new, starts
with creating a shell, spawning "()", and then closing the shell. Why
not make that a menu item since it is an obvious pattern?
