### PR TITLE
Webbrowser fixes

### DIFF
--- a/objects/applications/webBrowser/webBrowser.self
+++ b/objects/applications/webBrowser/webBrowser.self
@@ -809,7 +809,7 @@ SlotsToOmit: parent prototype.
               if:   [ sourceURL suffix uncapitalizeAll = 'gif' ]
               Then: [ buildGIFImage ]
               If:   [ sourceURL suffix uncapitalizeAll = 'jpg' ]
-              Then: [ buildJPGImageSource: (stripMimeHeader: sourceURL getContentsString) ]
+              Then: [ buildJPEGImageSource: (stripMimeHeader: sourceURL getContentsString) ]
               If:   [ sourceURL suffix uncapitalizeAll = 'png' ]
               Then: [ buildPNGImageSource: (stripMimeHeader: sourceURL getContentsString) ]
               If:   [ sourceURL suffix = 'xbm' ]


### PR DESCRIPTION
These two commits fix a couple of issues with the web browser code. One is a typo in calling a method to create a JPEG image. The other is for handling hex entities in HTML pages. The latter can be demonstrated by running the following:

```
bootstrap read: 'webBrowser' From: 'applications/webBrowser'
'http://bluishcoder.co.nz/index.html' asURL getPageForUser
```

This will load a page containing entities in hex format. The page gives an error without this commit. With this commit it loads further with one unrelated error later on due to not identifying an image.
