### PR TITLE
Workaround for userQueryMorph displaying black rectangles on Linux/X11

### DIFF
--- a/objects/ui2/userQueryMorph.self
+++ b/objects/ui2/userQueryMorph.self
@@ -1,8 +1,9 @@
  '$Revision: 30.14 $'
  '
-Copyright 1992-2012 AUTHORS.
-See the LICENSE file for license information.
+Copyright 1992-2014 AUTHORS.
+See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
+["preFileIn" self] value
 
 
  '-- Module body'
@@ -356,7 +357,7 @@ for user reponses are added via buttonLabel:Result:.
              new.
             | 
             new: copyRemoveAllMorphs beShrinkWrap.
-            new colorAll: paint copyRed: 0 Green: 0 Blue: 0 Alpha: 0.7.
+            "new colorAll: paint copyRed: 0 Green: 0 Blue: 0 Alpha: 0.7."
             new doneSema: (doneSema copyCount: 0 Capacity: 1).
             mphs: list copyRemoveAll.
             (queryText asTextLines) do: [| :line |


### PR DESCRIPTION
On An Unbuntu 14.10 linux system I'm seeing a black rectangle instead
of a box showing text when 'userQuery' is used. This can be seen when
saving the image from the middle click menu in the GUI. The text that
usually displays that the image is being saved does not appear,
instead a black rectangle where it would be displayed is shown
instead.

It can also be shown with:

    userQuery showEverybody: 'hello' While: [ times delay: 1000 ]

The commit comments out a line in `userQueryMorph>copyQuestionForNotice` that prevents this from happening. I don't think it's the right fix but it's a useful workaround. 