### PR TITLE
Set verdana family as alias of helvetica in X11.

### DIFF
--- a/objects/ui2/scalableFont.self
+++ b/objects/ui2/scalableFont.self
@@ -591,6 +591,27 @@ I print out as asterisks.\x7fModuleInfo: Module: scalableFont InitialContents: F
  bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'x11Globals' -> 'fontFamily' -> () From: ( | {
          'ModuleInfo: Module: scalableFont InitialContents: FollowSlot'
         
+         verdana = ( |
+            | helvetica).
+        } | ) 
+
+ bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'x11Globals' -> 'fontFamily' -> () From: ( | {
+         'ModuleInfo: Module: scalableFont InitialContents: FollowSlot'
+        
+         verdanaBold = ( |
+            | helveticaBold).
+        } | ) 
+
+ bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'x11Globals' -> 'fontFamily' -> () From: ( | {
+         'ModuleInfo: Module: scalableFont InitialContents: FollowSlot'
+        
+         verdanaItalic = ( |
+            | helveticaItalic).
+        } | ) 
+
+ bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'x11Globals' -> 'fontFamily' -> () From: ( | {
+         'ModuleInfo: Module: scalableFont InitialContents: FollowSlot'
+        
          zapfChancery = '-*-zapfchancery-medium-i-normal--'.
         } | ) 
 


### PR DESCRIPTION
X11 do not have verdana bitmap fonts, so set them as alias of helvetica.