### PR TITLE
Make editor color customizable by theme.

### DIFF
--- a/objects/ui2/outliner/generalModel.self
+++ b/objects/ui2/outliner/generalModel.self
@@ -1,6 +1,6 @@
  '$Revision: 30.19 $'
  '
-Copyright 1992-2014 AUTHORS.
+Copyright 1992-2016 AUTHORS.
 See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
 ["preFileIn" self] value
@@ -1602,6 +1602,13 @@ May cause me to expand if doExpand is true. -- dmu 10/04\x7fModuleInfo: Module: 
             | 
             "For non-pluggable outliner compatiblity"
             preferredBorderColor).
+        } | ) 
+
+ bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'generalModel' -> 'parent' -> () From: ( | {
+         'Category: appearance\x7fModuleInfo: Module: generalModel InitialContents: FollowSlot'
+        
+         preferredEditorColor = ( |
+            | preferences outliner theme generalModelEditor).
         } | ) 
 
  bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'generalModel' -> 'parent' -> () From: ( | {

--- a/objects/ui2/outliner/outlinerPreferences.self
+++ b/objects/ui2/outliner/outlinerPreferences.self
@@ -773,6 +773,13 @@ good for introducing language semantics, say.
         } | ) 
 
  bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'preferences' -> 'outliner' -> 'themes' -> 'base' -> () From: ( | {
+         'Category: colors\x7fModuleInfo: Module: outlinerPreferences InitialContents: FollowSlot'
+        
+         generalModelEditor = ( |
+            | bodyColor).
+        } | ) 
+
+ bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'preferences' -> 'outliner' -> 'themes' -> 'base' -> () From: ( | {
          'Category: colors\x7fCategory: menus\x7fModuleInfo: Module: outlinerPreferences InitialContents: FollowSlot'
         
          generalModelMenuColor = paint copyRed: 0.942326 Green: 0.904203  Blue: 0.815249.
@@ -1286,6 +1293,13 @@ good for introducing language semantics, say.
         
          float = ( |
             | dark).
+        } | ) 
+
+ bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'preferences' -> 'outliner' -> 'themes' -> 'night' -> () From: ( | {
+         'ModuleInfo: Module: outlinerPreferences InitialContents: FollowSlot'
+        
+         generalModelEditor = ( |
+            | dull).
         } | ) 
 
  bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'preferences' -> 'outliner' -> 'themes' -> 'night' -> () From: ( | {

--- a/objects/ui2/outliner/pluggableCommentStyle.self
+++ b/objects/ui2/outliner/pluggableCommentStyle.self
@@ -1,8 +1,9 @@
  '$Revision: 30.6 $'
  '
-Copyright 1992-2012 AUTHORS.
-See the LICENSE file for license information.
+Copyright 1992-2016 AUTHORS.
+See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
+["preFileIn" self] value
 
 
  '-- Module body'
@@ -83,6 +84,14 @@ SlotsToOmit: parent.
              {} = 'ModuleInfo: Creator: globals generalModel parent commentStyleProto parent.
 '.
             | ) .
+        } | ) 
+
+ bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'generalModel' -> 'parent' -> 'commentStyleProto' -> 'parent' -> () From: ( | {
+         'ModuleInfo: Module: pluggableCommentStyle InitialContents: FollowSlot'
+        
+         color = ( |
+            | 
+            myModel preferredEditorColor).
         } | ) 
 
  bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'generalModel' -> 'parent' -> 'commentStyleProto' -> 'parent' -> () From: ( | {

--- a/objects/ui2/outliner/pluggableContentsStyle.self
+++ b/objects/ui2/outliner/pluggableContentsStyle.self
@@ -1,8 +1,9 @@
  '$Revision: 30.6 $'
  '
-Copyright 1992-2012 AUTHORS.
-See the LICENSE file for license information.
+Copyright 1992-2016 AUTHORS.
+See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
+["preFileIn" self] value
 
 
  '-- Module body'
@@ -14,6 +15,13 @@ See the LICENSE file for license information.
              {} = 'ModuleInfo: Creator: globals generalModel parent contentsEditorStyleProto parent.
 '.
             | ) .
+        } | ) 
+
+ bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'generalModel' -> 'parent' -> 'contentsEditorStyleProto' -> 'parent' -> () From: ( | {
+         'ModuleInfo: Module: pluggableContentsStyle InitialContents: FollowSlot'
+        
+         color = ( |
+            | myModel preferredEditorColor).
         } | ) 
 
  bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'generalModel' -> 'parent' -> 'contentsEditorStyleProto' -> 'parent' -> () From: ( | {

--- a/objects/ui2/outliner/pluggableEditStyle.self
+++ b/objects/ui2/outliner/pluggableEditStyle.self
@@ -1,8 +1,9 @@
  '$Revision: 30.6 $'
  '
-Copyright 1992-2012 AUTHORS.
-See the LICENSE file for license information.
+Copyright 1992-2016 AUTHORS.
+See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
+["preFileIn" self] value
 
 
  '-- Module body'
@@ -30,6 +31,13 @@ SlotsToOmit: parent.
              {} = 'ModuleInfo: Creator: globals generalModel parent editWholeThingStyleProto parent.
 '.
             | ) .
+        } | ) 
+
+ bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'generalModel' -> 'parent' -> 'editWholeThingStyleProto' -> 'parent' -> () From: ( | {
+         'ModuleInfo: Module: pluggableEditStyle InitialContents: FollowSlot'
+        
+         color = ( |
+            | myModel preferredEditorColor).
         } | ) 
 
  bootstrap addSlotsTo: bootstrap stub -> 'globals' -> 'generalModel' -> 'parent' -> 'editWholeThingStyleProto' -> 'parent' -> () From: ( | {


### PR DESCRIPTION
This PR make editor usable in dark theme. Here's a screenshot.

![snapshot2](https://cloud.githubusercontent.com/assets/517130/19407698/fe957c52-92db-11e6-81f0-524e48033ea0.png)

This screenshot is run with this PR, PR #73 and following configurations:

```
preferences outliner theme: preferences outliner themes night.

preferences desktop backgroundColor: preferences outliner theme bodyColor.

selfCatOrObjModel moduleSummaryFontSpec size: 16.
selfGeneralSlotModel undeclaredTitleFontSpec size: 14.
selfGeneralSlotModel privateTitleFontSpec size: 14.
selfGeneralSlotModel publicTitleFontSpec size: 14.
generalCategoryModel objectTitleFontSpec size: 16.
generalCategoryModel objectTitleFontSpec style: 'bold'.
generalCategoryModel subcategoryTitleFontSpec size: 14.
ui2_textField fontSpec: globals fontSpec copyName: '9x15bold' Size: 15.
ui2Menu defaultFontSpec: ui2Menu defaultFontSpec copySize: 16.
```