### PR TITLE
Fix formatting in "10.8.1. Primitive failures".

### DIFF
--- a/docs/handbook/primitives.rst
+++ b/docs/handbook/primitives.rst
@@ -21,10 +21,10 @@ becomes ``_AsObjectIfFail``:, and ``_IntAdd``: becomes ``_IntAdd:IfFail:``.
 
 ::
 
-  > *3 _IntAdd: ’a’ IfFail: [ | :error. :name |
-  (name, ’ failed with ’, error, ’.’) printLine. 0 ]*
+  > 3 _IntAdd: ’a’ IfFail: [ | :error. :name |
+  (name, ’ failed with ’, error, ’.’) printLine. 0 ]
   _IntAdd: failed with badTypeError.
-  0        The primitive returns the result of evaluating the failure block.
+  0        "The primitive returns the result of evaluating the failure block."
   >
 
 When a primitive fails, if the primitive call has an ``IfFail``: part, the message ``value:With:`` is


### PR DESCRIPTION
Remove emphasis markup, as reST do not support do formatting inside code blocks, also comment out description text of the result.