### PR TITLE
Refine `abstractFile readLineIfFail:` and fix `prompt inputLoop`.

### DIFF
--- a/objects/core/abstract_OS.self
+++ b/objects/core/abstract_OS.self
@@ -1,6 +1,6 @@
  '$Revision: 30.16 $'
  '
-Copyright 1992-2014 AUTHORS.
+Copyright 1992-2016 AUTHORS.
 See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
 ["preFileIn" self] value
@@ -789,7 +789,7 @@ Return the expanded file name.\x7fModuleInfo: Module: abstract_OS InitialContent
              line <- ''.
             | 
             "Read up to and including first \n - skip this \n."
-            [ buf: readCount: 1 IfFail: fb. (buf != '\n') && [atEOF not] ] whileTrue: [ 
+            [ buf: readCount: 1 IfFail: [|:e| ^ fb value: e With: line]. buf != '\n' ] whileTrue: [ 
                 line: line, buf.
             ].
             line).

--- a/objects/core/prompt.self
+++ b/objects/core/prompt.self
@@ -1,8 +1,9 @@
  'Sun-$Revision: 30.8 $'
  '
-Copyright 1992-2011 AUTHORS.
+Copyright 1992-2016 AUTHORS.
 See the legal/LICENSE file for license information and legal/AUTHORS for authors.
 '
+["preFileIn" self] value
 
 
  '-- Module body'
@@ -297,7 +298,7 @@ is a sane default for perProcessGlobals prompt inputLoopProcess\x7fModuleInfo: C
             [stopping] whileFalse: [ | newInput <- ''. |
                 waitingForInput: true.
                 printPrompt.
-                newInput: stdin readLine.
+                newInput: stdin readLineIfFail: [|:e. :line| log error: e. line].
                 waitingForInput: false.
                 input: input, newInput.
                 stdin atEOF ifTrue: [


### PR DESCRIPTION
Trying to fix #89 and #92, just a prove of concept, may not be suitable to be merged.