### PR TITLE
vm: fix narrowing conversion from int to char warnings

### DIFF
--- a/vm/src/any/os/xlibWindow.cpp
+++ b/vm/src/any/os/xlibWindow.cpp
@@ -158,11 +158,12 @@ bool XPlatformWindow::setup_gcs() {
   // 16x16 grey stipple pixmap (16x16 is preferred stipple size)
   const int grey_width = 16;
   const int grey_height = 16;
-  static char grey_bits[] = {
+  static unsigned char grey_bits[] = {
     0x55, 0x55, 0xaa, 0xaa, 0x55, 0x55, 0xaa, 0xaa, 0x55, 0x55, 0xaa, 0xaa,
     0x55, 0x55, 0xaa, 0xaa, 0x55, 0x55, 0xaa, 0xaa, 0x55, 0x55, 0xaa, 0xaa,
     0x55, 0x55, 0xaa, 0xaa, 0x55, 0x55, 0xaa, 0xaa};
-  Pixmap stipple = XCreateBitmapFromData(_display, _xwindow, grey_bits,
+  Pixmap stipple = XCreateBitmapFromData(_display, _xwindow,
+                                         (const char *)grey_bits,
                                          grey_width, grey_height);
   XSetStipple(_display, _gc, stipple);
   


### PR DESCRIPTION
When compiled with g++ 6.3.1, I got the following error:

/home/lee/works/self/self/vm/src/any/os/xlibWindow.cpp: In member function ‘bool XPlatformWindow::setup_gcs()’:
/home/lee/works/self/self/vm/src/any/os/xlibWindow.cpp:164:51: error: narrowing conversion of ‘170’ from ‘int’ to ‘char’ inside { } [-Wnarrowing]
     0x55, 0x55, 0xaa, 0xaa, 0x55, 0x55, 0xaa, 0xaa};

This commit can fix this error.