### PR TITLE
Fix first send desc has wrong lookup type

### DIFF
--- a/vm/src/any/runtime/lprintf.cpp
+++ b/vm/src/any/runtime/lprintf.cpp
@@ -127,6 +127,12 @@ extern "C" void mysprintf(char*& buf, lprint_format_t fmt, ...) {
 
 
 volatile void fatal_handler() {
+  static bool in_fatal = false;
+  if (!in_fatal) {
+    in_fatal = true;
+  }
+  else
+    return;
   error_breakpoint();
   SignalInterface::simulate_fatal_signal();
   OS::terminate(-1);

--- a/vm/src/i386/runtime/asmDefs_gcc_i386.hh
+++ b/vm/src/i386/runtime/asmDefs_gcc_i386.hh
@@ -195,8 +195,9 @@ ENDMACRO
       ENDMACRO
 
       MACRO(jmp_label, label)
-        .globl \label // force 32-bits for the label
+	// make sure jmp occumpies 5 bytes
         jmp \label
+	nop; nop; nop
       ENDMACRO
     # else
       # error what?


### PR DESCRIPTION
When compiled with g++ 6.3.1, the generated Self could not start successfully, I got the following error:

first_sendDesc() has wrong lookup type

After the above error, it looks like fatal_handler is in a infinite loop, will call itself until the stack is overflowed eventually.  Therefore the first commit tries to stop fatal_handler enters that infinite loop.

The reason that the first_sendDesc got a wrong lookup type is that for the following i386 assembler language code:

.global label
jmp label

g++ 6.3.1 generated a 2-byte jmp instruction, instead of a 5-byte instruction, as required by the definition of lookupType_offset in vm/src/i386/lookup/sendDesc_i386.hh.  So the second commit adds three nop instructions to pad.