### PR TITLE
Feature/utf8 input

### DIFF
--- a/objects/ui2/ui2Event.self
+++ b/objects/ui2/ui2Event.self
@@ -1,6 +1,6 @@
  'Sun-$Revision: 30.24 $'
  '
-Copyright 1992-2012 AUTHORS.
+Copyright 1992-2017 AUTHORS.
 See the LICENSE file for license information.
 '
 
@@ -550,7 +550,7 @@ Feel free to inherit me and override the ones you can implement.
             | 
             combo nonmodifierKeyCap isArrow ifTrue: [^ handleSmallArrowPress: combo IfCannot: b].
 
-            combo nonmodifierKeyCap isPrintable ifTrue: [^combo nonmodifierKeyCap printString do: [|:c| insert_char: c]].
+            combo nonmodifierKeyCap printString size <= 6 ifTrue: [^combo nonmodifierKeyCap printString do: [|:c| insert_char: c]].
 
             combo nonmodifierKeyCap = keyCaps oddballs enter     ifTrue: [^ split_line].
             combo nonmodifierKeyCap = keyCaps oddballs backspace ifTrue: [^ backspace].

--- a/objects/ui2/ui2Event.self
+++ b/objects/ui2/ui2Event.self
@@ -547,10 +547,12 @@ Feel free to inherit me and override the ones you can implement.
          'Category: modifier-specific dispatching\x7fModuleInfo: Module: ui2Event InitialContents: FollowSlot\x7fVisibility: public'
         
          handlePressWithNoModifiers: combo IfCannot: b = ( |
+             longest_utf8_seq = 6.
             | 
+
             combo nonmodifierKeyCap isArrow ifTrue: [^ handleSmallArrowPress: combo IfCannot: b].
 
-            combo nonmodifierKeyCap printString size <= 6 ifTrue: [^combo nonmodifierKeyCap printString do: [|:c| insert_char: c]].
+            combo nonmodifierKeyCap printString size <= longest_utf8_seq ifTrue: [^combo nonmodifierKeyCap printString do: [|:c| insert_char: c]].
 
             combo nonmodifierKeyCap = keyCaps oddballs enter     ifTrue: [^ split_line].
             combo nonmodifierKeyCap = keyCaps oddballs backspace ifTrue: [^ backspace].

--- a/vm/src/unix/prims/xlibPrims.cpp
+++ b/vm/src/unix/prims/xlibPrims.cpp
@@ -7,6 +7,7 @@
  
 # pragma implementation "xlibPrims.hh"
 # include "_xlibPrims.cpp.incl"
+#include <X11/Xlocale.h>
 
   const char* Display_seal = "Display";
 
@@ -14,7 +15,11 @@
     // XOpenDisplay fails if a signal is received during the call.
     // All signals except user interrupts are therefore blocked. 
     SignalBlocker sb(SignalBlocker::allow_user_int);
-    
+
+    // support for unicode input
+    setlocale(LC_ALL, "");
+    XSetLocaleModifiers("@im=none");
+
     Display* result = XOpenDisplay(name);
     if (result == 0)  {
       prim_failure(FH, PRIMITIVEFAILEDERROR);


### PR DESCRIPTION
I've added UTF-8 input support (#113) under Xlib. Changes are explained in commit messages.

I am not so sure about the XICCache class, I've made for tracking XIM / XIC values for each X window. Some mechanism like this is required, but I can't stop feeling that this is inelegant solution. Also I am not sure about the XIM / XIC structures used in this class, because I've forgot half of C++ and I have strange feeling, that it would be better with pointers. And I have no idea whether they are properly destroyed or whether they are copied in memory too many times with each method call or what. Sorry. Someone please optimize this, if it is inefficient or leaks memory.

But the input works! I am now able to type into Self in my native language, with combining (dead) keys and all the glory:

    Příšerně žluťoučký kůň pěl ďábelské ódy.

(Yes, this was typed into Self and then copied out.)