### PR TITLE
Bugfix/i386 build

### DIFF
--- a/objects/applications/serverDemo/Makefile
+++ b/objects/applications/serverDemo/Makefile
@@ -9,9 +9,9 @@
 all: toself socks.so
 
 ROOT = ../../..
-CFLAGS=-DDEBUG -DGLUE_CHECKSUM=0 -DXLIB -DFAST_COMPILER -DSIC_COMPILER -DNATIVE_ARCH=i386 -DDYNLINK_SUPPORTED -DCOMPILER=GCC_COMPILER -DTARGET_OS_VERSION=LINUX_VERSION -DTARGET_OS_FAMILY=UNIX_FAMILY -DTARGET_ARCH=I386_ARCH -DHOST_ARCH=I386_ARCH -DGENERATE_DEBUGGING_AIDS=0 -DSPEND_TIME_FOR_DEBUGGING_BY_DEFAULT=0 -DTARGET_IS_OPTIMIZED=1 -DTARGET_IS_PROFILED=0 -DTARGET_IS_FOR_DEBUGGING=0 -m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
+CFLAGS=-DDEBUG -DGLUE_CHECKSUM=0 -DXLIB -DFAST_COMPILER -DSIC_COMPILER -DNATIVE_ARCH=i386 -DDYNLINK_SUPPORTED -DCOMPILER=GCC_COMPILER -DTARGET_OS_VERSION=LINUX_VERSION -DTARGET_OS_FAMILY=UNIX_FAMILY -DTARGET_ARCH=I386_ARCH -DHOST_ARCH=I386_ARCH -DGENERATE_DEBUGGING_AIDS=0 -DSPEND_TIME_FOR_DEBUGGING_BY_DEFAULT=0 -DTARGET_IS_OPTIMIZED=1 -DTARGET_IS_PROFILED=0 -DTARGET_IS_FOR_DEBUGGING=0 -m32 -fno-delete-null-pointer-checks -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
 
-LINKFLAGS=-m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
+LINKFLAGS=-m32 -fno-delete-null-pointer-checks -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
 
 
 INCLUDES  += -I$(ROOT)/incls \

--- a/objects/applications/serverDemo/Makefile
+++ b/objects/applications/serverDemo/Makefile
@@ -9,9 +9,9 @@
 all: toself socks.so
 
 ROOT = ../../..
-CFLAGS=-DDEBUG -DGLUE_CHECKSUM=0 -DXLIB -DFAST_COMPILER -DSIC_COMPILER -DNATIVE_ARCH=i386 -DDYNLINK_SUPPORTED -DCOMPILER=GCC_COMPILER -DTARGET_OS_VERSION=LINUX_VERSION -DTARGET_OS_FAMILY=UNIX_FAMILY -DTARGET_ARCH=I386_ARCH -DHOST_ARCH=I386_ARCH -DGENERATE_DEBUGGING_AIDS=0 -DSPEND_TIME_FOR_DEBUGGING_BY_DEFAULT=0 -DTARGET_IS_OPTIMIZED=1 -DTARGET_IS_PROFILED=0 -DTARGET_IS_FOR_DEBUGGING=0 -m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses
+CFLAGS=-DDEBUG -DGLUE_CHECKSUM=0 -DXLIB -DFAST_COMPILER -DSIC_COMPILER -DNATIVE_ARCH=i386 -DDYNLINK_SUPPORTED -DCOMPILER=GCC_COMPILER -DTARGET_OS_VERSION=LINUX_VERSION -DTARGET_OS_FAMILY=UNIX_FAMILY -DTARGET_ARCH=I386_ARCH -DHOST_ARCH=I386_ARCH -DGENERATE_DEBUGGING_AIDS=0 -DSPEND_TIME_FOR_DEBUGGING_BY_DEFAULT=0 -DTARGET_IS_OPTIMIZED=1 -DTARGET_IS_PROFILED=0 -DTARGET_IS_FOR_DEBUGGING=0 -m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
 
-LINKFLAGS=-m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses
+LINKFLAGS=-m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
 
 
 INCLUDES  += -I$(ROOT)/incls \

--- a/objects/applications/serverDemo/Makefile
+++ b/objects/applications/serverDemo/Makefile
@@ -9,9 +9,9 @@
 all: toself socks.so
 
 ROOT = ../../..
-CFLAGS=-DDEBUG -DGLUE_CHECKSUM=0 -DXLIB -DFAST_COMPILER -DSIC_COMPILER -DNATIVE_ARCH=i386 -DDYNLINK_SUPPORTED -DCOMPILER=GCC_COMPILER -DTARGET_OS_VERSION=LINUX_VERSION -DTARGET_OS_FAMILY=UNIX_FAMILY -DTARGET_ARCH=I386_ARCH -DHOST_ARCH=I386_ARCH -DGENERATE_DEBUGGING_AIDS=0 -DSPEND_TIME_FOR_DEBUGGING_BY_DEFAULT=0 -DTARGET_IS_OPTIMIZED=1 -DTARGET_IS_PROFILED=0 -DTARGET_IS_FOR_DEBUGGING=0 -m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses
+CFLAGS=-DDEBUG -DGLUE_CHECKSUM=0 -DXLIB -DFAST_COMPILER -DSIC_COMPILER -DNATIVE_ARCH=i386 -DDYNLINK_SUPPORTED -DCOMPILER=GCC_COMPILER -DTARGET_OS_VERSION=LINUX_VERSION -DTARGET_OS_FAMILY=UNIX_FAMILY -DTARGET_ARCH=I386_ARCH -DHOST_ARCH=I386_ARCH -DGENERATE_DEBUGGING_AIDS=0 -DSPEND_TIME_FOR_DEBUGGING_BY_DEFAULT=0 -DTARGET_IS_OPTIMIZED=1 -DTARGET_IS_PROFILED=0 -DTARGET_IS_FOR_DEBUGGING=0 -m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses
 
-LINKFLAGS=-m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses
+LINKFLAGS=-m32 -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses
 
 
 INCLUDES  += -I$(ROOT)/incls \

--- a/objects/applications/serverDemo/Makefile
+++ b/objects/applications/serverDemo/Makefile
@@ -9,9 +9,9 @@
 all: toself socks.so
 
 ROOT = ../../..
-CFLAGS=-DDEBUG -DGLUE_CHECKSUM=0 -DXLIB -DFAST_COMPILER -DSIC_COMPILER -DNATIVE_ARCH=i386 -DDYNLINK_SUPPORTED -DCOMPILER=GCC_COMPILER -DTARGET_OS_VERSION=LINUX_VERSION -DTARGET_OS_FAMILY=UNIX_FAMILY -DTARGET_ARCH=I386_ARCH -DHOST_ARCH=I386_ARCH -DGENERATE_DEBUGGING_AIDS=0 -DSPEND_TIME_FOR_DEBUGGING_BY_DEFAULT=0 -DTARGET_IS_OPTIMIZED=1 -DTARGET_IS_PROFILED=0 -DTARGET_IS_FOR_DEBUGGING=0 -m32 -fno-delete-null-pointer-checks -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
+CFLAGS=-DDEBUG -DGLUE_CHECKSUM=0 -DXLIB -DFAST_COMPILER -DSIC_COMPILER -DNATIVE_ARCH=i386 -DDYNLINK_SUPPORTED -DCOMPILER=GCC_COMPILER -DTARGET_OS_VERSION=LINUX_VERSION -DTARGET_OS_FAMILY=UNIX_FAMILY -DTARGET_ARCH=I386_ARCH -DHOST_ARCH=I386_ARCH -DGENERATE_DEBUGGING_AIDS=0 -DSPEND_TIME_FOR_DEBUGGING_BY_DEFAULT=0 -DTARGET_IS_OPTIMIZED=1 -DTARGET_IS_PROFILED=0 -DTARGET_IS_FOR_DEBUGGING=0 -m32 -fno-omit-frame-pointer -fno-delete-null-pointer-checks -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
 
-LINKFLAGS=-m32 -fno-delete-null-pointer-checks -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
+LINKFLAGS=-m32 -fno-omit-frame-pointer -fno-delete-null-pointer-checks -fno-threadsafe-statics -fvisibility=default -fkeep-inline-functions -fno-exceptions -fno-stack-protector -Wabi=11 -Wreorder -Wreturn-type -Wswitch -Wcomment -Wformat -Wpointer-arith -Woverloaded-virtual -Wno-write-strings -Wparentheses -Wno-register
 
 
 INCLUDES  += -I$(ROOT)/incls \

--- a/vm/cmake/setup.cmake
+++ b/vm/cmake/setup.cmake
@@ -51,7 +51,7 @@ endif()
 # setup all warning flags
 #
 list(APPEND _flags
-  -Wabi
+  -Wabi=11
   -Wreorder
   -Wreturn-type
   -Wswitch

--- a/vm/cmake/setup.cmake
+++ b/vm/cmake/setup.cmake
@@ -28,6 +28,7 @@ add_definitions_if_cmakevar(
 # setup all necessary build flags
 #
 list(APPEND _flags
+  -fno-omit-frame-pointer
   -fno-delete-null-pointer-checks
   -fno-threadsafe-statics
   -fvisibility=default

--- a/vm/cmake/setup.cmake
+++ b/vm/cmake/setup.cmake
@@ -61,4 +61,5 @@ list(APPEND _flags
   -Woverloaded-virtual
   -Wno-write-strings
   -Wparentheses
+  -Wno-register
 )

--- a/vm/cmake/setup.cmake
+++ b/vm/cmake/setup.cmake
@@ -28,6 +28,7 @@ add_definitions_if_cmakevar(
 # setup all necessary build flags
 #
 list(APPEND _flags
+  -fno-delete-null-pointer-checks
   -fno-threadsafe-statics
   -fvisibility=default
   -fno-exceptions

--- a/vm/src/any/objects/vframeOop.cpp
+++ b/vm/src/any/objects/vframeOop.cpp
@@ -139,8 +139,8 @@ vframeOop vframeOopClass::create_vframeOop(oop method) {
     ShouldNotReachHere(); // should create only three vframe prototypes
   vframeMap *vf;
   switch (method->kind()) {
-   case OuterMethodType: { ovframeMap m; vf= &m; break; }
-   case BlockMethodType: { bvframeMap m; vf= &m; break; }
+   case OuterMethodType: { static ovframeMap m; vf= &m; break; }
+   case BlockMethodType: { static bvframeMap m; vf= &m; break; }
    default: ShouldNotReachHere();
   }
   assert(sizeof(vframeMap) == sizeof(bvframeMap) &&

--- a/vm/src/any/runtime/asserts.hh
+++ b/vm/src/any/runtime/asserts.hh
@@ -14,7 +14,7 @@ extern bool CheckAssertions; // defined in debug.h but need it sooner
 
 # if GENERATE_DEBUGGING_AIDS
 # define assert(b,msg)                                                        \
-    if (!CheckAssertions  ||  b) {} else fatal1("assertion failed:  %s",(msg[0] ? msg : XSTR(b)))
+    if (!CheckAssertions  ||  (b)) {} else fatal1("assertion failed:  %s",(msg[0] ? msg : XSTR(b)))
 # else
 # define assert(b,msg)
 # endif


### PR DESCRIPTION
With this changes I can compile Self with gcc 11.3 as both `Release` and `RelWithDebInfo` and get a working world snapshot.

Changes to `serverDemo/Makefile` are pro-forma, to keep the options in sync with cmake.   I haven't tried to build it.  Changes to `LINKFLAGS` there are doubly so as the `-f` and `-W` options don't affect the link command, but I wanted to keep the `CFLAGS` in `LINKFLAGS` in sync.