### PR TITLE
Bring back PowerPC port (NB: not working)

### DIFF
--- a/vm/cmake/platform.cmake
+++ b/vm/cmake/platform.cmake
@@ -10,6 +10,14 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "^Intel" OR
   set(TARGET_ARCH       "I386_ARCH")
   set(HOST_ARCH         "I386_ARCH")
   
+elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^powerpc" OR
+       CMAKE_SYSTEM_PROCESSOR MATCHES "^Power" OR
+       CMAKE_SYSTEM_PROCESSOR MATCHES "^ppc")
+    
+  set(platform_processor "ppc")
+  set(TARGET_ARCH       "PPC_ARCH")
+  set(HOST_ARCH         "PPC_ARCH")
+
 elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^sparc")
   
   set(platform_processor "sparc")

--- a/vm/src/CMakeLists.txt
+++ b/vm/src/CMakeLists.txt
@@ -506,6 +506,85 @@ set(SRC_i386
   i386/zone/trapdoors_i386.cpp
   i386/zone/trapdoors_i386.hh
 )
+set(SRC_ppc
+  ppc/asm/asm_inline_ppc.hh
+  ppc/asm/asm_ppc.cpp
+  ppc/asm/asm_ppc.hh
+  ppc/asm/disasm_ppc.cpp
+  ppc/asm/disasm_ppc.hh
+  ppc/asm/fields_ppc.cpp
+  ppc/asm/fields_ppc.hh
+  ppc/asm/regs_ppc.cpp
+  ppc/asm/regs_ppc.hh
+  ppc/fast_compiler/codeGen_inline_ppc.hh
+  ppc/fast_compiler/codeGen_ppc.cpp
+  ppc/fast_compiler/codeGen_ppc.hh
+  ppc/fast_compiler/fcompiler_ppc.cpp
+  ppc/fast_compiler/fcompiler_ppc.hh
+  ppc/fast_compiler/registerState_ppc.cpp
+  ppc/fast_compiler/registerState_ppc.hh
+  ppc/fast_compiler/registerString_ppc.cpp
+  ppc/fast_compiler/registerString_ppc.hh
+  ppc/lookup/cacheStub_inline_ppc.hh
+  ppc/lookup/cacheStub_ppc.cpp
+  ppc/lookup/cacheStub_ppc.hh
+  ppc/lookup/diDesc_ppc.cpp
+  ppc/lookup/diDesc_ppc.hh
+  ppc/lookup/sendDesc_ppc.cpp
+  ppc/lookup/sendDesc_ppc.hh
+  ppc/memory/search_ppc.cpp
+  ppc/memory/search_ppc.hh
+  ppc/prims/asmPrims_gcc_ppc.S
+#  ppc/prims/asmPrims_mw_ppc.S only metrowerks
+  ppc/prims/prim_table_arch_ppc.hh
+  ppc/runtime/aCompiler_ppc.cpp
+  ppc/runtime/aCompiler_ppc.hh
+  ppc/runtime/asmDefs_gcc_ppc.hh
+#  ppc/runtime/asmDefs_mw_ppc.hh
+  ppc/runtime/conversion_ppc.cpp
+  ppc/runtime/conversion_ppc.hh
+  ppc/runtime/frame_format_ppc.cpp
+  ppc/runtime/frame_format_ppc.hh
+  ppc/runtime/frame_iterator_ppc.cpp
+  ppc/runtime/frame_iterator_ppc.hh
+  ppc/runtime/frame_ppc.cpp
+  ppc/runtime/frame_ppc.hh
+  ppc/runtime/framePieces_ppc.cpp
+  ppc/runtime/framePieces_ppc.hh
+  ppc/runtime/interruptedCtx_ppc.cpp
+  ppc/runtime/interruptedCtx_ppc.hh
+  ppc/runtime/registerLocator_ppc.cpp
+  ppc/runtime/registerLocator_ppc.hh
+  ppc/runtime/runtime_asm_gcc_ppc.S
+#  ppc/runtime/runtime_asm_mw_ppc.S
+  ppc/runtime/runtime_ppc.cpp
+  ppc/runtime/runtime_ppc.hh
+  ppc/runtime/stubs_ppc.cpp
+  ppc/runtime/uncommonBranch_ppc.cpp
+  ppc/runtime/vframe_ppc.cpp
+  ppc/sic/basicNode_ppc.hh
+  ppc/sic/deadBlockNode_ppc.cpp
+  ppc/sic/deadBlockNode_ppc.hh
+  ppc/sic/genHelper_ppc.cpp
+  ppc/sic/genHelper_ppc.hh
+  ppc/sic/longRegString_ppc.cpp
+  ppc/sic/longRegString_ppc.hh
+  ppc/sic/node_ppc.cpp
+  ppc/sic/prologueNode_ppc.hh
+  ppc/sic/sic_ppc.cpp
+  ppc/sic/sic_ppc.hh
+  ppc/zone/addrDesc_ppc.cpp
+  ppc/zone/addrDesc_ppc.hh
+  ppc/zone/allocZone_ppc.S
+  ppc/zone/countPattern_ppc.cpp
+  ppc/zone/countPattern_ppc.hh
+  ppc/zone/countStub_ppc.cpp
+  ppc/zone/countStub_ppc.hh
+  ppc/zone/nmethod_ppc.cpp
+  ppc/zone/nmethod_ppc.hh
+  ppc/zone/trapdoors_ppc.cpp
+  ppc/zone/trapdoors_ppc.hh
+)
 set(SRC_sparc
   sparc/asm/asm_inline_sparc.hh
   sparc/asm/asm_sparc.cpp

--- a/vm/src/any/runtime/allocation.cpp
+++ b/vm/src/any/runtime/allocation.cpp
@@ -345,7 +345,8 @@ static int32 true_size_of_malloced_obj(int32* p) {
     # include <malloc.h> // for mallopt
 # endif
 
-# if TARGET_OS_VERSION == NETBSD_VERSION && TARGET_ARCH == I386_ARCH
+# if TARGET_OS_VERSION == NETBSD_VERSION \
+    && (TARGET_ARCH == I386_ARCH || TARGET_ARCH == PPC_ARCH)
 /* Ask jemalloc to use sbrk. */
 const char *__je_malloc_conf = "dss:primary";
 # endif

--- a/vm/src/ppc/asm/asm_inline_ppc.hh
+++ b/vm/src/ppc/asm/asm_inline_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.9 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/asm/asm_ppc.hh
+++ b/vm/src/ppc/asm/asm_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.13 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/asm/asm_ppc.hh
+++ b/vm/src/ppc/asm/asm_ppc.hh
@@ -402,7 +402,7 @@ class Assembler: public BaseAssembler {
     if (printing)  lprintf("  %s  %s%s, %s\n",  name, cbf_print_str(cf), RegisterNames[ra], RegisterNames[rb]); 
   }
 
-  void XOForm( XOpExts xop, char* n, char* fmt, void* p1, void* p2, void* p3, Location rt, Location ra, Location rb, int32 oe, int32 rc ) {
+  void XOForm( XOpExts xop, char* n, char* fmt, const void* p1, const void* p2, const void* p3, Location rt, Location ra, Location rb, int32 oe, int32 rc ) {
     assemble( OPCD(opcd_XO) | RT(rt) | RA(ra) | RB(rb) | OE(oe) | XO1(xop) | Rc(rc));
     if (printing)  { lprintf("  %s", n);  lprintf(fmt, p1, p2, p3); }
   }
@@ -415,7 +415,7 @@ class Assembler: public BaseAssembler {
    }
 
   
-  void DFormSI(char* fmt, void* p1, void* p2, void* p3, OPCD_codes op, Location rt, Location ra, int32 si, OperandType t, Kind_of_Instruction_Field f ) {
+  void DFormSI(char* fmt, const void* p1, const void* p2, const void* p3, OPCD_codes op, Location rt, Location ra, int32 si, OperandType t, Kind_of_Instruction_Field f ) {
      add_offset(t, f);
      assemble( OPCD(op) | RT(rt) | RA( ra) | SI(si)); 
      if (printing) lprintf(fmt, p1, p2, p3);
@@ -475,7 +475,7 @@ class Assembler: public BaseAssembler {
     
   
   void RotateDoublewordImmMD( Location rs, Location ra, int32 n, int32 b, int32 mdxo, int32 rc, bool assrt,
-                              char* fmt, void* p1, void* p2, void* p3, void* p4 ) {
+                              char* fmt, const void* p1, const void* p2, const void* p3, const void* p4 ) {
     assert(assrt, "oops");  UsedOnlyInAssert(assrt);
     assemble(  OPCD(opcd_DoublewordRotate) | RS(rs) | RA(ra) | DSH(n) | DMB(b) | MDXO(mdxo) | Rc(rc));
     if (printing) {
@@ -486,7 +486,7 @@ class Assembler: public BaseAssembler {
   }
   
   void RotateWordImmM( OPCD_codes op, Location rs, Location ra, int32 sh, int32 mb, int32 me, int32 rc, bool assrt,
-                        char* fmt, void* p1, void* p2, void* p3, void* p4, void* p5 ) {
+                        char* fmt, const void* p1, const void* p2, const void* p3, const void* p4, const void* p5 ) {
     assert(assrt, "oops");  UsedOnlyInAssert(assrt);
     assemble(  OPCD(op) | RS(rs) | RA(ra) | WSH(sh) | WMB(mb) | ME(me) | Rc(rc));
     if (printing) {
@@ -498,7 +498,7 @@ class Assembler: public BaseAssembler {
   
   
   void RotateDoublewordRegMDS( Location rs, Location ra, Location rb, int32 b, int32 mdxo, int32 rc, bool assrt,
-                              char* fmt, void* p1, void* p2, void* p3, void* p4 ) {
+                              char* fmt, const void* p1, const void* p2, const void* p3, const void* p4 ) {
     assert(assrt, "oops");  UsedOnlyInAssert(assrt);
     assemble(  OPCD(opcd_DoublewordRotate) | RS(rs) | RA(ra) | RB(rb) | DMB(b) | MDXO(mdxo) | Rc(rc));
     if (printing) {
@@ -509,7 +509,7 @@ class Assembler: public BaseAssembler {
   }
   
   void RotateWordRegM( Location rs, Location ra, Location rb, int32 b, int32 me, int32 rc, bool assrt,
-                         char* fmt, void* p1, void* p2, void* p3, void* p4, void* p5 ) {
+                         char* fmt, const void* p1, const void* p2, const void* p3, const void* p4, const void* p5 ) {
     assert(assrt, "oops");  UsedOnlyInAssert(assrt);
     assemble(  OPCD(opcd_RotateLeftWordThenAndMask) | RS(rs) | RA(ra) | RB(rb) | WMB(b) | ME(me) | Rc(rc));
     if (printing) {
@@ -520,7 +520,7 @@ class Assembler: public BaseAssembler {
   }    
   
   void ShiftRightAlgebraicDoublewordImm( Location rs, Location ra, int32 n, int32 rc,
-                                         char* fmt, void* p1, void* p2, void* p3) {
+                                         char* fmt, const void* p1, const void* p2, const void* p3) {
     assemble(  OPCD(opcd_XO) | RS(rs) | RA(ra) | DSH(n) | XO2(ShiftRightAlgebraicDoublewordImmediateXOp) | Rc(rc));
     if (printing) {
       lprintf("  ");
@@ -530,7 +530,7 @@ class Assembler: public BaseAssembler {
   }
   
   void ShiftRightAlgebraicWordImm( Location rs, Location ra, int32 n, int32 rc,
-                                         char* fmt, void* p1, void* p2, void* p3) {
+                                         char* fmt, const void* p1, const void* p2, const void* p3) {
     assemble(  OPCD(opcd_XO) | RS(rs) | RA(ra) | WSH(n) | XO1(ShiftRightAlgebraicWordImmediateXOp) | Rc(rc));
     if (printing) {
       lprintf("  ");
@@ -1245,83 +1245,83 @@ class Assembler: public BaseAssembler {
   
   // rotate left doubleword immedate then clear left
   void rldicl( Location ra, Location rs, int32 n, int32 b, bool assrt = true,  char* fmt = "rldicl  %s, %s, %d, %d", 
-               void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+               const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                  RotateDoublewordImmMD( rs, ra, n, b, 0, 0, assrt,  fmt, p1, p2, p3, p4);
   }
   void rldicl_( Location ra, Location rs, int32 n, int32 b, bool assrt = true,  char* fmt = "rldicl_  %s, %s, %d, %d", 
-                void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                   RotateDoublewordImmMD( rs, ra, n, b, 0, 1, assrt,  fmt, p1, p2, p3, p4);
   }
   // rotate left doubleword immedate then clear right
   void rldicr( Location ra, Location rs, int32 n, int32 b, bool assrt = true,  char* fmt = "rldicr  %s, %s, %d, %d", 
-               void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  {
+               const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  {
                  RotateDoublewordImmMD( rs, ra, n, b, 1, 0, assrt,  fmt, p1, p2, p3, p4);
   }
   void rldicr_( Location ra, Location rs, int32 n, int32 b, bool assrt = true,  char* fmt = "rldicr_  %s, %s, %d, %d", 
-                void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                   RotateDoublewordImmMD( rs, ra, n, b, 1, 1, assrt,  fmt, p1, p2, p3, p4);
   }
   // rotate left doubleword immediate then clear
   void rldic(  Location ra, Location rs, int32 n, int32 b, bool assrt = true,  char* fmt = "rldimi  %s, %s, %d, %d", 
-               void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  {
+               const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  {
                  RotateDoublewordImmMD( rs, ra, n, b, 2, 0, assrt,  fmt, p1, p2, p3, p4);
   }
   void rldic_(  Location ra, Location rs, int32 n, int32 b, bool assrt = true,  char* fmt = "rldimi_  %s, %s, %d, %d", 
-                void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                   RotateDoublewordImmMD( rs, ra, n, b, 2, 1, assrt,  fmt, p1, p2, p3, p4);
   }
   // rotate left word immediate then and with mask
   void rlwinm(  Location ra, Location rs, int32 sh, int32 mb, int32 me, bool assrt = true,  char* fmt = "rlwinm  %s, %s, %d, %d, %d",  
-                void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0, void* p5 = 0 ) {
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0, const void* p5 = 0 ) {
                   RotateWordImmM( opcd_RotateLeftWordThenAndMaskImm, rs, ra, sh, mb, me, 0, assrt,  fmt, p1, p2, p3, p4, p5);
   }
   void rlwinm_( Location ra, Location rs, int32 sh, int32 mb, int32 me, bool assrt = true,  char* fmt = "rlwinm_  %s, %s, %d, %d, %d",  
-                void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0, void* p5 = 0 ) {
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0, const void* p5 = 0 ) {
                   RotateWordImmM( opcd_RotateLeftWordThenAndMaskImm, rs, ra, sh, mb, me, 1, assrt,  fmt, p1, p2, p3, p4, p5);
   }
   // rotate left doubleword then clear
   void rldcl(  Location ra, Location rs, Location rb, int32 b, bool assrt = true,  char* fmt = "rldcl  %s, %s, %s, %d", 
-               void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+               const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                  RotateDoublewordRegMDS( rs, ra, rb, b, 8, 0, assrt,  fmt, p1, p2, p3, p4);
   }
   void rldcl_( Location ra, Location rs, Location rb, int32 b, bool assrt = true,  char* fmt = "rldcl_  %s, %s, %s, %d", 
-               void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+               const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                  RotateDoublewordRegMDS( rs, ra, rb, b, 8, 1, assrt,  fmt, p1, p2, p3, p4);
   }
   // rotate left doubleword then clear right
   void rldcr(  Location ra, Location rs, Location rb, int32 b, bool assrt = true,  char* fmt = "rldcr  %s, %s, %s, %d", 
-               void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+               const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                  RotateDoublewordRegMDS( rs, ra, rb, b, 9, 0, assrt,  fmt, p1, p2, p3, p4);
   }
   void rldcr_( Location ra, Location rs, Location rb, int32 b, bool assrt = true,  char* fmt = "rldcr_  %s, %s, %s, %d", 
-               void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+               const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                  RotateDoublewordRegMDS( rs, ra, rb, b, 9, 1, assrt,  fmt, p1, p2, p3, p4);
   }
   // rotate left word then and with mask
   void rlwnm(  Location ra, Location rs, Location rb, int32 mb, int32 me, bool assrt = true,  char* fmt = "rlwnm  %s, %s, %s, %d, %d",  
-                void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0, void* p5 = 0 ) {
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0, const void* p5 = 0 ) {
                   RotateWordRegM( rs, ra, rb, mb, me, 0, assrt,  fmt, p1, p2, p3, p4, p5);
   }
   void rlwnm_(  Location ra, Location rs, Location rb, int32 mb, int32 me, bool assrt = true,  char* fmt = "rlwnm_  %s, %s, %s, %d, %d",  
-                void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = (void*)0, void* p5 = (void*)0 ) {
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0, const void* p5 = 0 ) {
                   RotateWordRegM( rs, ra, rb, mb, me, 1, assrt,  fmt, p1, p2, p3, p4, p5);
   }
   // rotate left word immedate then and with mask
   void rldimi(  Location ra, Location rs, int32 n, int32 b, bool assrt = true,  char* fmt = "rldic  %s, %s, %d, %d", 
-                void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                  RotateDoublewordImmMD( rs, ra, n, b, 3, 0, assrt,  fmt, p1, p2, p3, p4);
   }
   void rldimi_(  Location ra, Location rs, int32 n, int32 b, bool assrt = true,  char* fmt = "rldic_  %s, %s, %d, %d", 
-                 void* p1 = 0, void* p2 = 0, void* p3 = 0, void* p4 = 0 )  { 
+                 const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0 )  { 
                    RotateDoublewordImmMD( rs, ra, n, b, 3, 1, assrt,  fmt, p1, p2, p3, p4);
   }
   // rotate left word immediate then mask insert
   void rlwimi(  Location ra, Location rs, int32 sh, int32 mb, int32 me, bool assrt = true,  char* fmt = "rlwimi  %s, %s, %d, %d, %d",  
-                void* p1 = 0, void* p2 = 0, void* p3 = (void*)0, void* p4 = 0, void* p5 = 0 ) {
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0, const void* p5 = 0 ) {
                   RotateWordImmM( opcd_RotateLeftWordImmThenMaskInsert, rs, ra, sh, mb, me, 0, assrt,  fmt, p1, p2, p3, p4, p5);
   }
   void rlwimi_( Location ra, Location rs, int32 sh, int32 mb, int32 me, bool assrt = true,  char* fmt = "rlwimi_  %s, %s, %d, %d, %d",  
-                void* p1 = 0, void* p2 = 0, void* p3 = (void*)0, void* p4 = 0, void* p5 = 0 ) {
+                const void* p1 = 0, const void* p2 = 0, const void* p3 = 0, const void* p4 = 0, const void* p5 = 0 ) {
                   RotateWordImmM( opcd_RotateLeftWordImmThenMaskInsert, rs, ra, sh, mb, me, 1, assrt,  fmt, p1, p2, p3, p4, p5);
   }
 

--- a/vm/src/ppc/asm/disasm_ppc.hh
+++ b/vm/src/ppc/asm/disasm_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.9 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/asm/fields_ppc.hh
+++ b/vm/src/ppc/asm/fields_ppc.hh
@@ -208,7 +208,7 @@ inline fint OP(inst_t inst)   { return (unsigned int)inst >> 26; }
 inline fint XOP1(inst_t inst) { return (inst >> 1) &  ((1 << 10)-1); }
 inline fint SPR(inst_t inst)  { 
   int32 i = inst >> 11;
-  return  (i >> 5) & 31  |  ((i & 31) << 5);
+  return  ((i >> 5) & 31)  |  ((i & 31) << 5);
 }
 
 
@@ -245,7 +245,7 @@ inline bool isAddingInst(inst_t inst) {
 
 inline inst_t signExtend(int32 field_bit_size, int32 i) {
   return   i
-        | (i   &   1 << field_bit_size-1    
+        | (i   &   1 << (field_bit_size-1)
            ?   ~0 << field_bit_size   
            :    0 ); 
 }
@@ -419,13 +419,13 @@ inline int32 conditionalImmediateBranch_target(inst_t* instp) {
 inline void set_unconditionalImmediateBranch_target(inst_t* instp, int32 nv) {
   inst_t inst = *instp;
   if (!absoluteBit(inst)) nv -= int32(instp);  
-  *instp = inst & ~li_mask  |  li_mask & nv;
+  *instp = (inst & ~li_mask)  |  (li_mask & nv);
   MachineCache::flush_instruction_cache_word(instp);
 }
 inline void   set_conditionalImmediateBranch_target(inst_t* instp, int32 nv) {
   inst_t inst = *instp;
   if (!absoluteBit(inst)) nv -= int32(instp);
-  *instp = inst & ~bd_mask  |  bd_mask & nv;
+  *instp = (inst & ~bd_mask)  |  (bd_mask & nv);
   MachineCache::flush_instruction_cache_word(instp);
 }
 

--- a/vm/src/ppc/asm/fields_ppc.hh
+++ b/vm/src/ppc/asm/fields_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.12 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/asm/regs_ppc.cpp
+++ b/vm/src/ppc/asm/regs_ppc.cpp
@@ -10,7 +10,7 @@
 
 
 // change Location enum in regs_ppc.h if you change this!
-char* RegisterNames[] = {
+const char *RegisterNames[] = {
     "r0",  "sp",  "rtoc", "r3",   "r4",  "r5",  "r6",  "r7",
     "r8",  "r9",  "r10",  "r11",  "r12", "r13", "r14", "r15",
     "r16", "r17", "r18",  "r19",  "r20", "r21", "r22", "r23",
@@ -19,17 +19,17 @@ char* RegisterNames[] = {
     "*UnAllocated*"
 };
     
-char *StackArgRegisterNames[] = {
+const char * const StackArgRegisterNames[] = {
   "A0", "A1", "A2", "A3", "A4", "A5", "A6", "A7", 
   "A8", "A9", "A10", "A11", "A12", "A13", "A14", "A15"
 };
 
-char *StackIArgRegisterNames[] = {
+const char * const StackIArgRegisterNames[] = {
   "I0", "I1", "I2", "I3", "I4", "I5", "I6", "I7", 
   "I8", "I9", "I10", "I11", "I12", "I13", "I14", "I15"
 };
     
-char *StackLocationNames[] = {
+const char * const StackLocationNames[] = {
   "S0", "S1", "S2", "S3", "S4", "S5", "S6", "S7", 
   "S8", "S9", "S10", "S11", "S12", "S13", "S14", "S15"
 };
@@ -45,9 +45,9 @@ Location IArgRegisters[] = {
 };
 
   
-static char* locationNameHelper(Location base, int num) {
+static const char* locationNameHelper(Location base, int num) {
   char c;
-  char **tbl;
+  const char * const *tbl;
   switch (base) {
     case  ArgStackLocations:     tbl=   StackArgRegisterNames;  c= 'A';  break;
     case IArgStackLocations:     tbl=  StackIArgRegisterNames;  c= 'I';  break;
@@ -62,7 +62,7 @@ static char* locationNameHelper(Location base, int num) {
   return s;
 }
 
-char *locationName(Location l) {
+const char *locationName(Location l) {
   Location base;
   int num;
   

--- a/vm/src/ppc/asm/regs_ppc.hh
+++ b/vm/src/ppc/asm/regs_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.15 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/fast_compiler/codeGen_inline_ppc.hh
+++ b/vm/src/ppc/fast_compiler/codeGen_inline_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.10 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/fast_compiler/codeGen_ppc.hh
+++ b/vm/src/ppc/fast_compiler/codeGen_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.10 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/fast_compiler/fcompiler_ppc.hh
+++ b/vm/src/ppc/fast_compiler/fcompiler_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.10 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/fast_compiler/registerState_ppc.hh
+++ b/vm/src/ppc/fast_compiler/registerState_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.9 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/fast_compiler/registerString_ppc.hh
+++ b/vm/src/ppc/fast_compiler/registerString_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.10 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/lookup/cacheStub_inline_ppc.hh
+++ b/vm/src/ppc/lookup/cacheStub_inline_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.11 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/lookup/cacheStub_ppc.hh
+++ b/vm/src/ppc/lookup/cacheStub_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.11 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/lookup/diDesc_ppc.hh
+++ b/vm/src/ppc/lookup/diDesc_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.10 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/lookup/sendDesc_ppc.hh
+++ b/vm/src/ppc/lookup/sendDesc_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.11 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/memory/search_ppc.cpp
+++ b/vm/src/ppc/memory/search_ppc.cpp
@@ -7,6 +7,9 @@
 # pragma implementation "search_ppc.hh"
 # include "_search_ppc.cpp.incl"
 
+#if TARGET_OS_VERSION == NETBSD_VERSION
+#include <altivec.h>
+#endif
 
 
 // sw pipelining for 1-case, xpose for many case

--- a/vm/src/ppc/memory/search_ppc.hh
+++ b/vm/src/ppc/memory/search_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.10 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/prims/asmPrims_gcc_ppc.S
+++ b/vm/src/ppc/prims/asmPrims_gcc_ppc.S
@@ -1,4 +1,4 @@
-# ifdef  __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 ; // Sun-$Revision: 30.7 $
 
 ;/* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/prims/asmPrims_gcc_ppc.S
+++ b/vm/src/ppc/prims/asmPrims_gcc_ppc.S
@@ -1,119 +1,117 @@
 # if defined(__ppc__) || defined(__powerpc__)
-; // Sun-$Revision: 30.7 $
+// Sun-$Revision: 30.7 $
 
-;/* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
-;   See the LICENSE file for license information. */
+/* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
+   See the LICENSE file for license information. */
 
 /* remove me from MW project when compiling under MW */
 
-; some integer primitives
+// some integer primitives
 
 
-;  .include "../../src/ppc/runtime/asmDefs_gcc_ppc.hh"
+//  .include "../../src/ppc/runtime/asmDefs_gcc_ppc.hh"
 # include "asmDefs_gcc_ppc.hh"
 
 
 
-    .macro ret_prim_error // error_code
-    import_data_address      r3,VMString
-    lwz            r3, $0(r3)
-    addi           r3, r3, Mark_Tag - Mem_Tag
-    blr
-    .endmacro
+#define ret_prim_error(error_code)		  \
+	import_data_address(r3, VMString)	; \
+	lwz	r3, error_code(r3)		; \
+	addi	r3, r3, Mark_Tag - Mem_Tag	; \
+	blr
 
-        .macro arith_prim // &name, &opcode
-        start_exported_function $0
-        or      r0, rcv, arg
-        andi.   r0, r0, Tag_Mask
-        beq      $0_OK
-        ret_prim_error badTypeOffset
-$0_OK:  mcrxr   0 ; clear sum ovfl bit
-        $1 rcv, rcv, arg // have to put dot here, not in arg--why?s
-        bnslr
-        ret_prim_error overflowOffset
-       .endmacro
-        
-        arith_prim smi_add_prim, addo.
-        arith_prim smi_sub_prim, subo.
+
+#define arith_prim(name, opcode)	  \
+    start_exported_function(name)	; \
+	or	r0, rcv, arg		; \
+	andi.	r0, r0, Tag_Mask	; \
+	beq	name ## _OK		; \
+	ret_prim_error(badTypeOffset)	; \
+name ## _OK:				  \
+	/* clear sum ovfl bit */	  \
+	mcrxr	0			; \
+        opcode	rcv, rcv, arg	; \
+        bnslr				; \
+        ret_prim_error(overflowOffset)
+
+arith_prim(smi_add_prim, addo. )
+arith_prim(smi_sub_prim, subo. )
   
         
-        start_exported_function smi_mul_prim
+start_exported_function(smi_mul_prim)
         or      r0, rcv, arg
         andi.   r0, r0, Tag_Mask
         beq     smi_mul_prim_OK
-        ret_prim_error badTypeOffset
+        ret_prim_error(badTypeOffset)
 smi_mul_prim_OK: 
-        srawi   arg, arg, 2 ; shift out tag
-        mcrxr   0 ; clear sum ovfl bit
-        mullwo. rcv, rcv, arg
+        srawi   arg, arg, 2	// shift out tag
+        mcrxr   0		// clear sum ovfl bit
+        mullwo.	rcv, rcv, arg
         bnslr
-        ret_prim_error overflowOffset
+        ret_prim_error(overflowOffset)
         
 
-    .macro log_prim // &name, &opcode
-    start_exported_function $0
-    or    r0, rcv, arg
-    andi. r0, r0, Tag_Mask
-    beq    $0_OK
-    ret_prim_error badTypeOffset
-$0_OK:  $1  rcv, rcv, arg
-    blr
-    .endmacro
+#define log_prim(name, opcode)		  \
+    start_exported_function(name)	; \
+	or	r0, rcv, arg		; \
+	andi.	r0, r0, Tag_Mask	; \
+	beq	name ## _OK		; \
+	ret_prim_error(badTypeOffset)	; \
+name ## _OK:				  \
+	opcode	rcv, rcv, arg	; \
+	blr
           
-          
-    log_prim smi_and_prim, and
-    log_prim smi_or_prim,   or
-    log_prim smi_xor_prim, xor
+log_prim(smi_and_prim, and)
+log_prim(smi_or_prim,   or)
+log_prim(smi_xor_prim, xor)
 
 
-    start_exported_function smi_complement_prim
-    andi.     r0, rcv, Tag_Mask
-    beq       smi_complement_prim_ok
-    ret_prim_error badTypeOffset
-smi_complement_prim_ok: 
-    not       r3, r3
-    li        r0, Tag_Mask
-    andc    r3, r3, r0
-    blr
+start_exported_function(smi_complement_prim)
+	andi.	r0, rcv, Tag_Mask
+	beq	smi_complement_prim_OK
+	ret_prim_error(badTypeOffset)
+smi_complement_prim_OK: 
+	not	r3, r3
+	li	r0, Tag_Mask
+	andc	r3, r3, r0
+	blr
 
-    start_exported_function smi_arithmetic_shift_left_prim      
-    or      r0, rcv, arg
-    andi.   r0, r0, Tag_Mask
-    beq      smi_arithmetic_shift_left_prim_ok
-    ret_prim_error badTypeOffset
-smi_arithmetic_shift_left_prim_ok:
-    srawi   arg, arg, 2 ; shift out tag
-    mr      r5, rcv
-    slw.    rcv, rcv, arg
-    xor.    r5, r5, rcv ; see if sign bit changed
-    bgelr
-    ret_prim_error overflowOffset
+start_exported_function(smi_arithmetic_shift_left_prim)
+	or	r0, rcv, arg
+	andi.	r0, r0, Tag_Mask
+	beq	smi_arithmetic_shift_left_prim_OK
+	ret_prim_error(badTypeOffset)
+smi_arithmetic_shift_left_prim_OK:
+	srawi	arg, arg, 2	// shift out tag
+	mr	r5, rcv
+	slw.	rcv, rcv, arg
+	xor.	r5, r5, rcv	// see if sign bit changed
+	bgelr
+	ret_prim_error(overflowOffset)
 
 
-    .macro simple_shift_prim // &name, &opcode
-                start_exported_function  $0
-    or      r0, rcv, arg
-    andi.   r0, r0, Tag_Mask
-    beq     1f
-    ret_prim_error badTypeOffset
-    1:      srawi   arg, arg, 2 ; shift out tag
-    $1  rcv, rcv, arg
-    .endmacro
+#define simple_shift_prim(name, opcode)	  \
+    start_exported_function(name)	; \
+	or	r0, rcv, arg		; \
+	andi.	r0, r0, Tag_Mask	; \
+	beq	1f			; \
+	ret_prim_error(badTypeOffset)	; \
+1:					  \
+	/* shift out tag */		  \
+	srawi	arg, arg, 2		; \
+	opcode	rcv, rcv, arg
 
-                // removed _ from smi below for project builder:
-                simple_shift_prim smi_logical_shift_left_prim, slw
-    blr
+simple_shift_prim(smi_logical_shift_left_prim, slw)
+	blr
 
-                // removed _ from smi below for project builder:
-    simple_shift_prim smi_logical_shift_right_prim, srw
-    li     Temp1, ~Tag_Mask; need to mask tag bits on right shift
-    and    rcv, rcv, Temp1
-    blr
+simple_shift_prim(smi_logical_shift_right_prim, srw)
+	li	Temp1, ~Tag_Mask // need to mask tag bits on right shift
+	and	rcv, rcv, Temp1
+	blr
 
-                // removed _ from smi below for project builder:
-    simple_shift_prim smi_arithmetic_shift_right_prim, sraw
-    li     Temp1, ~Tag_Mask; need to mask tag bits on right shift
-    and    rcv, rcv, Temp1
-    blr
-        
+simple_shift_prim(smi_arithmetic_shift_right_prim, sraw)
+	li	Temp1, ~Tag_Mask // need to mask tag bits on right shift
+	and	rcv, rcv, Temp1
+	blr
+
 # endif // TARGET_ARCH == PPC_ARCH

--- a/vm/src/ppc/prims/prim_table_arch_ppc.hh
+++ b/vm/src/ppc/prims/prim_table_arch_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.8 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/aCompiler_ppc.hh
+++ b/vm/src/ppc/runtime/aCompiler_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.10 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/asmDefs_gcc_ppc.hh
+++ b/vm/src/ppc/runtime/asmDefs_gcc_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 // Sun-$Revision: 30.9 $ 
 
 // Copyright 1992-9 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/asmDefs_mw_ppc.hh
+++ b/vm/src/ppc/runtime/asmDefs_mw_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 #/* Sun-$Revision: 30.9 $ */
 
 #/* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/conversion_ppc.hh
+++ b/vm/src/ppc/runtime/conversion_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.9 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/framePieces_ppc.hh
+++ b/vm/src/ppc/runtime/framePieces_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.9 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/frame_format_ppc.hh
+++ b/vm/src/ppc/runtime/frame_format_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.13 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/frame_format_ppc.hh
+++ b/vm/src/ppc/runtime/frame_format_ppc.hh
@@ -13,6 +13,7 @@
 /*
 
 Inside Macintosh: Introduction to PowerPC System Software, 1-44
+https://developer.apple.com/library/archive/documentation/mac/pdf/PPC_System_Software/Intro_to_PowerPC.pdf
 
 stack overview:
 

--- a/vm/src/ppc/runtime/frame_iterator_ppc.hh
+++ b/vm/src/ppc/runtime/frame_iterator_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.10 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/frame_ppc.hh
+++ b/vm/src/ppc/runtime/frame_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.12 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/interruptedCtx_ppc.hh
+++ b/vm/src/ppc/runtime/interruptedCtx_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.11 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/registerLocator_ppc.hh
+++ b/vm/src/ppc/runtime/registerLocator_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.11 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
+++ b/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 ; // Sun-$Revision: 30.14 $
 
 

--- a/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
+++ b/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
@@ -464,23 +464,20 @@ base_fr_size =   LinkageArea_size/oopSize + NumRcvrAndArgRegisters + -SaveSelfNo
 # define  vol_reg_count  r30
 
 
-                .macro load_global_nonvol_regs
-                import_data_address(ByteMapBaseReg, byte_map_base)
-                import_data_address(SPLimitReg, SPLimit)
-                lwz     ByteMapBaseReg, 0(ByteMapBaseReg)
+#define load_global_nonvol_regs						  \
+                import_data_address(ByteMapBaseReg, byte_map_base)	; \
+                import_data_address(SPLimitReg, SPLimit)		; \
+                lwz     ByteMapBaseReg, 0(ByteMapBaseReg)		; \
                 lwz     SPLimitReg,     0(SPLimitReg)
-                .endmacro
 
                 
                 // need to reuse the save sequence, so macrofy it
-                .macro save_local_nonvol_regs
+#define save_local_nonvol_regs \
                 stmw    LowestLocalNonVolReg, -(size_of_gpr * NumLocalNonVolRegisters)(sp)
-                .endmacro
                  
                 // need to reuse the load sequence, so macrofy it
-                .macro restore_local_nonvol_regs // &base, &disp
-                lmw     LowestLocalNonVolReg, ($1 -(size_of_gpr * NumLocalNonVolRegisters))($0)
-                .endmacro
+#define restore_local_nonvol_regs(base, disp) \
+                lmw     LowestLocalNonVolReg, (disp -(size_of_gpr * NumLocalNonVolRegisters))(base)
                 
                 start_exported_function(SaveSelfNonVolRegs)        
 SaveSelfNonVolRegs_start:
@@ -519,7 +516,7 @@ start_exported_function(SaveSelfNonVolRegs_returnPC)
 return_normally:
                 lwz     sp, LinkageArea_savedSP(sp) // pop frame
                 lwz     r0, LinkageArea_savedPC(sp)
-                restore_local_nonvol_regs sp, 0
+                restore_local_nonvol_regs(sp, 0)
                 mtlr    r0
                 blr
 
@@ -527,7 +524,7 @@ return_nlr:
                 lwz     sp, LinkageArea_savedSP(sp) // pop frame
                 lwz     Temp1, LinkageArea_savedPC(sp)
                 addi    Temp1, Temp1, non_local_return_offset
-                restore_local_nonvol_regs sp, 0
+                restore_local_nonvol_regs(sp, 0)
                 mtlr    Temp1
                 blr
                 
@@ -583,7 +580,7 @@ skipFirstPop:   lwz     r0, LinkageArea_savedPC(sp)
                 bne+    not_saved1
                 // At this point sp is sp for SaveNonVol frame
                 lwz     Temp2, LinkageArea_savedSP(sp)  // get top of savenonvol frame
-                restore_local_nonvol_regs Temp2, 0
+                restore_local_nonvol_regs(Temp2, 0)
                 
 not_saved1:
                 cmpw    r0, ret_addr                    // test ret pc
@@ -646,7 +643,7 @@ notFound2:      lwz     r0, LinkageArea_savedPC(sp)
                 cmpw    r0, Temp1                         // look for savenonvol frame
                 bne+    not_saved2
                 lwz     Temp2, LinkageArea_savedSP(sp)  // get top of savenonvol frame
-                restore_local_nonvol_regs Temp2, 0
+                restore_local_nonvol_regs(Temp2, 0)
 not_saved2:
                 lwz     sp, LinkageArea_savedSP(sp)     // pop frame
 loop_entry_point1:                
@@ -691,7 +688,7 @@ notFound3:      lwz     r0, LinkageArea_savedPC(sp)
                 cmpw    r0, Temp1                         // look for savenonvol frame
                 bne+    not_saved3
                 lwz     Temp2, LinkageArea_savedSP(sp)  // get top of savenonvol frame
-                restore_local_nonvol_regs Temp2, 0
+                restore_local_nonvol_regs(Temp2, 0)
 not_saved3:
                 lwz     sp, LinkageArea_savedSP(sp)     // pop frame
 loop_entry_point2:                
@@ -876,7 +873,7 @@ start_exported_function(SendMessage_stub_returnPC) // for stack-walking
                  lswi  r3, Temp1, NumRcvrAndArgRegisters * oopSize
                  
                  la    sp, frsize(sp)//  restore sp
-                 restore_local_nonvol_regs sp, 0
+                 restore_local_nonvol_regs(sp, 0)
                  lwz  r0, LinkageArea_savedPC(sp)//  restore link
                  mtlr  r0
                  
@@ -948,7 +945,7 @@ start_exported_function(SendDIMessage_stub_returnPC) // for stack-walking
                  lswi  r3, Temp1, NumRcvrAndArgRegisters * oopSize
                  
                  la    sp, frsize(sp)//  restore sp
-                 restore_local_nonvol_regs sp, 0
+                 restore_local_nonvol_regs(sp, 0)
                  lwz   r0, LinkageArea_savedPC(sp)//  restore link
                  mtlr  r0
                  
@@ -1009,7 +1006,7 @@ start_exported_function(MakeOld_stub_returnPC) // for stack-walking
                  lswi  r3, Temp1, NumRcvrAndArgRegisters * oopSize
                  
                  la    sp, frsize(sp)//  restore sp
-                 restore_local_nonvol_regs sp, 0
+                 restore_local_nonvol_regs(sp, 0)
                  lwz   r0, LinkageArea_savedPC(sp)//  restore link
                  mtlr  r0
   
@@ -1137,7 +1134,7 @@ pf2:
                  lswi  arg0 /* also normal result reg */, Temp1, numVolRegsToSave * oopSize
                  
                  la    sp, ProfilerTrap_frame_size(sp)
-                 restore_local_nonvol_regs sp, 0
+                 restore_local_nonvol_regs(sp, 0)
                  mtlr  Temp2
                  blr
                  
@@ -1230,7 +1227,7 @@ start_exported_function(Recompile_stub_returnPC) // for stack-walking
                  
                  la    sp, frsize(sp)//  restore sp
                  lwz   r0, LinkageArea_savedPC(sp)//  restore link
-                 restore_local_nonvol_regs sp, 0
+                 restore_local_nonvol_regs(sp, 0)
                  mtlr  r0
                  
                  bctr//  branch to counter reg

--- a/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
+++ b/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
@@ -1,9 +1,9 @@
 # if defined(__ppc__) || defined(__powerpc__)
-; // Sun-$Revision: 30.14 $
+// Sun-$Revision: 30.14 $
 
 
- ; Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
- ;   See the LICENSE file for license information.
+// Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
+//   See the LICENSE file for license information.
 
 
 /* remove me from MW project when compiling under MW */
@@ -24,15 +24,15 @@
     blr
 
     start_exported_function set_SPLimitReg
-    mr   SPLimitReg, r3 ; relies on C not using this register (ugh)
+    mr   SPLimitReg, r3 // relies on C not using this register (ugh)
     blr
 
     start_exported_function save1Arg
-    ; save arg1 in stack frame
-    stw    r3, LinkageArea_size(sp) ; arg area is right after linkage area
+    // save arg1 in stack frame
+    stw    r3, LinkageArea_size(sp) // arg area is right after linkage area
     blr
 
-  ;-----------------------------------------------------------------
+  //-----------------------------------------------------------------
                 
                 
 allNVFPRs_sf31 = 0 - size_of_fpr
@@ -56,17 +56,17 @@ allNVFPRs_sf14 = allNVFPRs_sf15 - size_of_fpr
 
 allNVFPRs_size = -allNVFPRs_sf14
                 
- ; local def            
+// local def            
 
 
   
- ;  1. make new stack frame & save all registers in it
- ;  2. if (callerSaveAddr) store fp, return addr into callerSaveAddr[0], [1]
- ;  3. if (!init)        restore fp, return addr from calleeSaveAddr[0], [1]
- ;                        clear semaphore, restore regs & return to return addr
- ;  4 else                setup new stack fp,sp starting at calleeSaveAddr[0]
- ;                        (ensure trap if return past top)
- ;                        clear semaphore, jump to calleeSaveAddr[1]
+//  1. make new stack frame & save all registers in it
+//  2. if (callerSaveAddr) store fp, return addr into callerSaveAddr[0], [1]
+//  3. if (!init)        restore fp, return addr from calleeSaveAddr[0], [1]
+//                        clear semaphore, restore regs & return to return addr
+//  4 else                setup new stack fp,sp starting at calleeSaveAddr[0]
+//                        (ensure trap if return past top)
+//                        clear semaphore, jump to calleeSaveAddr[1]
 
 locals_for_sf_size = 0
 rounded_locals_for_sf_size = (locals_for_sf_size + 7) & ~7
@@ -81,7 +81,7 @@ FrameTop_bot  = FrameTop_lcls_top - round(locals_for_sf_size, size_of_gpr)
 FrameTop_size = FrameTop_top - FrameTop_bot
 
                 
-Frame_bot = 0                ; assume qw alignment
+Frame_bot = 0                // assume qw alignment
 Frame_LinkageArea = Frame_bot
 Frame_FrameTop_top = Frame_LinkageArea + round(LinkageArea_size + FrameTop_size, alignment_of_sp)
 Frame_top = Frame_FrameTop_top
@@ -89,10 +89,10 @@ Frame_size = Frame_top - Frame_bot
 
 
  
- ; process switch primitive
- ; NOTE ASSUMES switching within same code segment:
- ;   void  SetSPAndCall( char** callerSaveAddr, char** calleeSaveAddr,
- ;                      bool init, bool* semaphore); (bool == char)
+// process switch primitive
+// NOTE ASSUMES switching within same code segment:
+//   void  SetSPAndCall( char** callerSaveAddr, char** calleeSaveAddr,
+//                      bool init, bool* semaphore)// (bool == char)
 
   
 # define callerSaveAddr  r3
@@ -107,13 +107,13 @@ saveAddr_SP = 0
 saveAddr_PC = size_of_gpr
 
   
-  ; next bit inspired by MPW PPC ASM manual, pg 1-6
-  ; must save/restore nonvol regs: r13 and up, Fr14 and up, and parts of CR
-  ; if asserts, should also zero out all others, incl ctr (count), xer, fp execption,
-  ;  fpscr fp status & control reg
+  // next bit inspired by MPW PPC ASM manual, pg 1-6
+  // must save/restore nonvol regs: r13 and up, Fr14 and up, and parts of CR
+  // if asserts, should also zero out all others, incl ctr (count), xer, fp execption,
+  //  fpscr fp status & control reg
   
   
- ; first make new stack frame & save all registers in it
+// first make new stack frame & save all registers in it
 
 start_exported_function SetSPAndCall
         mflr    link
@@ -123,7 +123,7 @@ start_exported_function SetSPAndCall
         mr      fp,sp
         stwu    sp, LinkageArea_savedSP - Frame_size (sp)
         
- ;  2. if (callerSaveAddr) store fp, return addr into callerSaveAddr[0], [1]
+//  2. if (callerSaveAddr) store fp, return addr into callerSaveAddr[0], [1]
         
         cmpwi   callerSaveAddr, 0
         beq     noSave
@@ -156,8 +156,8 @@ noSave:
         stw     rtoc, LinkageArea_savedRTOC(sp)
         
         
- ;  3. if (!init)        restore fp, return addr from calleeSaveAddr[0], [1]
- ;                        clear semaphore, restore regs & return to return addr
+//  3. if (!init)        restore fp, return addr from calleeSaveAddr[0], [1]
+//                        clear semaphore, restore regs & return to return addr
         
         lwz     sp,saveAddr_SP(calleeSaveAddr)
         lwz     r0,saveAddr_PC(calleeSaveAddr)
@@ -173,7 +173,7 @@ noSave:
         
         lwz     r0,LinkageArea_savedCR(fp)
         mtcr    r0
-        ; lwz   rtoc,LinkageArea_savedRTOC(sp)
+        // lwz   rtoc,LinkageArea_savedRTOC(sp)
         
         lmw     LowestNonVolReg, FrameTop_gprs_top(fp)
                 
@@ -215,22 +215,22 @@ noSave:
         # endif
                 
         blr
-        nop ; just in case the linker messes  us up
+        nop // just in case the linker messes  us up
         
- ;  4 else                setup new stack fp,sp starting at calleeSaveAddr[0]
- ;                        (ensure trap if return past top)
- ;                        clear semaphore, jump to calleeSaveAddr[1]
+//  4 else                setup new stack fp,sp starting at calleeSaveAddr[0]
+//                        (ensure trap if return past top)
+//                        clear semaphore, jump to calleeSaveAddr[1]
 
-FirstFrame      = 0 ; assume qw alignment
+FirstFrame      = 0 // assume qw alignment
 FirstFrame_bot = FirstFrame
 FirstFrame_top = round(LinkageArea_size, alignment_of_sp)
 FirstFrame_size = FirstFrame_top
 
 firstTimeThisProcess:
         li      r0,15
-        andc    sp,sp,r0 ;; align by 16
+        andc    sp,sp,r0 // align by 16
         li      r0, 0
-        stwu    r0, LinkageArea_savedSP - FirstFrame_size(sp)      ;; decr & store null sp
+        stwu    r0, LinkageArea_savedSP - FirstFrame_size(sp)      // decr & store null sp
         import_function_address r3,ReturnOffTopOfProcess
         stw     r3,LinkageArea_savedPC(sp)
         
@@ -274,9 +274,9 @@ firstTimeThisProcess:
         lwz     sp,LinkageArea_savedSP(sp)
         blr
         
-; =============================================
-; SwitchStack0 switches back toVm stack with 0 arguments
-;; Actually it passes 4 args, so it can be reused to inplement the others
+// =============================================
+// SwitchStack0 switches back toVm stack with 0 arguments
+/// Actually it passes 4 args, so it can be reused to inplement the others
         
         
         
@@ -299,7 +299,7 @@ switch_stack:
         mflr    r0
         stw     r0, LinkageArea_savedPC(sp)
         mr      r0, sp
-        la      sp, -SwSFrame_size(lastSP) ; set sp
+        la      sp, -SwSFrame_size(lastSP) // set sp
         stw     r0, LinkageArea_savedSP(sp)
 
         mtlr    newPC
@@ -330,18 +330,18 @@ switch_stack:
         b switch_stack
         
         
-; ===========================================
+// ===========================================
 
-; CallPrimitiveFromInterpreter
+// CallPrimitiveFromInterpreter
         
         
-  ; called with entry point, rcv, argp, arg_count
+  // called with entry point, rcv, argp, arg_count
   
 
-reg_save_len    = 4 * size_of_gpr; 4 words to preserve alignment
+reg_save_len    = 4 * size_of_gpr// 4 words to preserve alignment
 
-                ; assume qw alignment
-CPFIFrame_bot  = 0 ; qw alignment
+                // assume qw alignment
+CPFIFrame_bot  = 0 // qw alignment
 CPFIFrame_argsave = LinkageArea_size
 CPFIFrame_regsave = round(CPFIFrame_argsave  +  4 * size_of_gpr, alignment_of_lsmul_top)
 CPFIFrame_top     = CPFIFrame_regsave   + reg_save_len 
@@ -362,17 +362,17 @@ linkage_len     = 12
   start_exported_function CallPrimitiveFromInterpreter
   
         mflr    r0
-        stw     r0,LinkageArea_savedPC(sp) ; save link
+        stw     r0,LinkageArea_savedPC(sp) // save link
         
-        stmw    r28,-reg_save_len(sp) ; save 4 nonvol regs
+        stmw    r28,-reg_save_len(sp) // save 4 nonvol regs
         
-        slwi    scr_a, arg_count_a, 2 ; words to bytes
-        sub     scr_a,  sp, scr_a       ; scr_a now has sp - arg length
-        addi    scr_a, scr_a, -(LinkageArea_size + reg_save_len) ; and - linkage_len - reg_save_len
+        slwi    scr_a, arg_count_a, 2 // words to bytes
+        sub     scr_a,  sp, scr_a       // scr_a now has sp - arg length
+        addi    scr_a, scr_a, -(LinkageArea_size + reg_save_len) // and - linkage_len - reg_save_len
         li      r0, 15
-        andc    scr_a, scr_a, r0  ; round down
+        andc    scr_a, scr_a, r0  // round down
         stw     sp,0(scr_a)
-        mr      sp, scr_a ; setup sp for new frame
+        mr      sp, scr_a // setup sp for new frame
         
         mtlr    entry_pt_a
         mr      r3, rcv_a
@@ -382,7 +382,7 @@ linkage_len     = 12
         addi    r0, arg_count, 1
         mtctr   r0
         
-        ; redo to use lswx someday:
+        // redo to use lswx someday:
         bdz     endRegArgs
         lwz     r4,  0(argp)
         bdz     endRegArgs
@@ -404,7 +404,7 @@ linkage_len     = 12
 endRegArgs:
         mtctr   r0
         addi    argp, argp, -oopSize
-        la      scr_b, LinkageArea_size - oopSize (sp) ; put start of args in frame in scr_b
+        la      scr_b, LinkageArea_size - oopSize (sp) // put start of args in frame in scr_b
         bdz     endRegMem
         
 regMemLoop:     lwzu    r0,oopSize(argp)
@@ -413,25 +413,25 @@ regMemLoop:     lwzu    r0,oopSize(argp)
                 
 endRegMem:      
                 stw     rtoc,LinkageArea_savedRTOC(sp)
-                blrl    ; go!
-                lwz     rtoc,LinkageArea_savedRTOC(sp) ; reload, although others do not
+                blrl    // go!
+                lwz     rtoc,LinkageArea_savedRTOC(sp) // reload, although others do not
                 lwz     sp,LinkageArea_savedSP(sp)
-                lmw     r28,-reg_save_len(sp) ; restore nonvol gprs
+                lmw     r28,-reg_save_len(sp) // restore nonvol gprs
                 lwz     r0,LinkageArea_savedPC(sp)
                 mtlr    r0
                 blr
 
- ; ---------------------------------------------------------
- ; SaveSelfNonVolRegs
+// ---------------------------------------------------------
+// SaveSelfNonVolRegs
 
- ; Problem: VM needs to walk stack to find all oops to do GC etc.
- ; But callee-saved regs are saved wherever.
- ; Solution: when Self calls a C-routine that might walk the stack,
- ; go through me. Pass args the usual way, pass fn entry point in r11 (Temp1) and
- ; pass # of args (including receiver) in r12.
+// Problem: VM needs to walk stack to find all oops to do GC etc.
+// But callee-saved regs are saved wherever.
+// Solution: when Self calls a C-routine that might walk the stack,
+// go through me. Pass args the usual way, pass fn entry point in r11 (Temp1) and
+// pass # of args (including receiver) in r12.
  
  
-; WARNING: next two defines are DUPLICATED in regs_ppc.hh
+// WARNING: next two defines are DUPLICATED in regs_ppc.hh
 # define SaveSelfNonVolRegs_entry_point_register Temp1
 # define SaveSelfNonVolRegs_arg_count_register   Temp2
 
@@ -443,19 +443,19 @@ endRegMem:
 # define dstp         r27
 
 
- ; frame contains saved nonvols, room for callee to save all r3-r10 possible incoming reg args
- ; frame includes all nonvols, all arg regs (for C to save into me) + space for mem args
+// frame contains saved nonvols, room for callee to save all r3-r10 possible incoming reg args
+// frame includes all nonvols, all arg regs (for C to save into me) + space for mem args
  
- ; As of 1/03 I am changing this routine to always save the incoming arg regs so
- ; that when we patch a frame we can get at the outgoing arguments for restarting a send
- ; -- dmu                
+// As of 1/03 I am changing this routine to always save the incoming arg regs so
+// that when we patch a frame we can get at the outgoing arguments for restarting a send
+// -- dmu                
 
-; save volatiles for return trap handling...use the area that my caller might use anyway
-; WARNING: DUPLICATED in runtime_ppc.hh
+// save volatiles for return trap handling...use the area that my caller might use anyway
+// WARNING: DUPLICATED in runtime_ppc.hh
 
-; Do not use the area for C callees to save register args, no telling what
-; they will put there. Instead, allocate an area relative to the TOP of my frame,
-; since I do not statically know my number of outgoing args. -- dmu
+// Do not use the area for C callees to save register args, no telling what
+// they will put there. Instead, allocate an area relative to the TOP of my frame,
+// since I do not statically know my number of outgoing args. -- dmu
 SaveSelfNonVolRegs_volatile_register_fp_offset = -(NumLocalNonVolRegisters + NumRcvrAndArgRegisters)
 
 base_fr_size =   LinkageArea_size/oopSize + NumRcvrAndArgRegisters + -SaveSelfNonVolRegs_volatile_register_fp_offset
@@ -484,24 +484,24 @@ base_fr_size =   LinkageArea_size/oopSize + NumRcvrAndArgRegisters + -SaveSelfNo
                 
                 start_exported_function SaveSelfNonVolRegs        
 SaveSelfNonVolRegs_start:
-                mflr    r0 ; save link
+                mflr    r0 // save link
                 stw     r0, LinkageArea_savedPC(sp)
                 save_local_nonvol_regs                
                
-                ; which case?
+                // which case?
                 cmpwi   SaveSelfNonVolRegs_arg_count_register, NumRcvrAndArgRegisters
-                bgt     extra_args;  have at least 1 extra
+                bgt     extra_args//  have at least 1 extra
                 
-                ; common case: no extra args
+                // common case: no extra args
                 
-                ; save the right number of vol regs
-                ; save outgoing volatiles for frame patching/return trap handling
+                // save the right number of vol regs
+                // save outgoing volatiles for frame patching/return trap handling
                 la    vol_base, (SaveSelfNonVolRegs_volatile_register_fp_offset * oopSize)(sp) 
-                slwi  vol_reg_count, SaveSelfNonVolRegs_arg_count_register, 2 ; in BYTES
-                mtxer vol_reg_count ; byte count -> bottom bits of XER
-                stswx r3, 0, vol_base ; store the registers
+                slwi  vol_reg_count, SaveSelfNonVolRegs_arg_count_register, 2 // in BYTES
+                mtxer vol_reg_count // byte count -> bottom bits of XER
+                stswx r3, 0, vol_base // store the registers
 
-                stwu    sp, -round(base_fr_size * size_of_gpr, alignment_of_sp) (sp); DUPLICATED in lmw below and in ContinueNLRFromC above
+                stwu    sp, -round(base_fr_size * size_of_gpr, alignment_of_sp) (sp)// DUPLICATED in lmw below and in ContinueNLRFromC above
                 
 do_call:        
                 mtlr    SaveSelfNonVolRegs_entry_point_register
@@ -509,22 +509,22 @@ do_call:
                 
 start_exported_function SaveSelfNonVolRegs_returnPC
                 b       return_normally
-                .long    0 ; mask
+                .long    0 // mask
                 b       return_nlr
-                .long    0 ; nmln, not sure if needed
-                .long    0 ; ditto
+                .long    0 // nmln, not sure if needed
+                .long    0 // ditto
                 
-                ; unwind stack and return
+                // unwind stack and return
                 
 return_normally:
-                lwz     sp, LinkageArea_savedSP(sp) ; pop frame
+                lwz     sp, LinkageArea_savedSP(sp) // pop frame
                 lwz     r0, LinkageArea_savedPC(sp)
                 restore_local_nonvol_regs sp, 0
                 mtlr    r0
                 blr
 
 return_nlr:
-                lwz     sp, LinkageArea_savedSP(sp) ; pop frame
+                lwz     sp, LinkageArea_savedSP(sp) // pop frame
                 lwz     Temp1, LinkageArea_savedPC(sp)
                 addi    Temp1, Temp1, non_local_return_offset
                 restore_local_nonvol_regs sp, 0
@@ -532,23 +532,23 @@ return_nlr:
                 blr
                 
                 
-                ; compute frame size: add # extra args to base, * oopSize and round to quadword
+                // compute frame size: add # extra args to base, * oopSize and round to quadword
 extra_args:     
-                ; save outgoing volatiles for frame patching/return trap handling
+                // save outgoing volatiles for frame patching/return trap handling
                 la    vol_base, (SaveSelfNonVolRegs_volatile_register_fp_offset * oopSize)(sp) 
-                stswi r3,  vol_base,  NumRcvrAndArgRegisters * oopSize ; save all vol regs
+                stswi r3,  vol_base,  NumRcvrAndArgRegisters * oopSize // save all vol regs
                 
                 subi    excess_arg_count, SaveSelfNonVolRegs_arg_count_register, NumRcvrAndArgRegisters
-                addi    frame_size, excess_arg_count, base_fr_size + 3 ; + 3 for rounding  
-                andi.   frame_size, frame_size, 0xfffc; finish rounding
-                slwi    frame_size, frame_size, 2 ; shift word count to byte count
-                neg     frame_size, frame_size ; need to decrement SP
+                addi    frame_size, excess_arg_count, base_fr_size + 3 // + 3 for rounding  
+                andi.   frame_size, frame_size, 0xfffc// finish rounding
+                slwi    frame_size, frame_size, 2 // shift word count to byte count
+                neg     frame_size, frame_size // need to decrement SP
                 
-                mr      caller_sp, sp; will need this for arg copying
-                stwux   sp, sp, frame_size ; finally! make frame
+                mr      caller_sp, sp// will need this for arg copying
+                stwux   sp, sp, frame_size // finally! make frame
                 
-                ; now need to copy those excess args
-                ; setup src and dst regs, need to point to word BEFORE the first word to move
+                // now need to copy those excess args
+                // setup src and dst regs, need to point to word BEFORE the first word to move
                 addi    srcp, caller_sp, LinkageArea_size  +  NumRcvrAndArgRegisters * size_of_gpr  -  size_of_gpr
                 addi    dstp,        sp, LinkageArea_size  +  NumRcvrAndArgRegisters * size_of_gpr  -  size_of_gpr
                 mtctr   excess_arg_count
@@ -560,12 +560,12 @@ do_another:     lwzu    r0, size_of_gpr(srcp)
                 b       do_call
                                   
 
- ; ------------------------------------------------------
- ; ContinueNLRFromC
+// ------------------------------------------------------
+// ContinueNLRFromC
  
- ; When C code wants to continue an NLR, it calls here
+// When C code wants to continue an NLR, it calls here
  
- ; Also need to restore nonvols if encounter a SaveSelfNonVolRegs_returnPC frame
+// Also need to restore nonvols if encounter a SaveSelfNonVolRegs_returnPC frame
 
         
 # define ret_addr        rcv  // return address
@@ -573,26 +573,26 @@ do_another:     lwzu    r0, size_of_gpr(srcp)
 # define self_ic_flag    arg2 // called from Self ic?
         
 
-start_exported_function ContinueNLRFromC    ; called by VM 
-                ; pop VM frames
-                import_function_address     Temp1,SaveSelfNonVolRegs_returnPC; get save stub return PC
+start_exported_function ContinueNLRFromC    // called by VM 
+                // pop VM frames
+                import_function_address     Temp1,SaveSelfNonVolRegs_returnPC// get save stub return PC
                  b       skipFirstPop
-notFound1:      lwz     sp, LinkageArea_savedSP(sp)     ; pop frame
+notFound1:      lwz     sp, LinkageArea_savedSP(sp)     // pop frame
 skipFirstPop:   lwz     r0, LinkageArea_savedPC(sp)
-                cmpw    r0, Temp1                         ; look for savenonvol frame
+                cmpw    r0, Temp1                         // look for savenonvol frame
                 bne+    not_saved1
-                ; At this point sp is sp for SaveNonVol frame
-                lwz     Temp2, LinkageArea_savedSP(sp)  ; get top of savenonvol frame
+                // At this point sp is sp for SaveNonVol frame
+                lwz     Temp2, LinkageArea_savedSP(sp)  // get top of savenonvol frame
                 restore_local_nonvol_regs Temp2, 0
                 
 not_saved1:
-                cmpw    r0, ret_addr                    ; test ret pc
+                cmpw    r0, ret_addr                    // test ret pc
                 bne     notFound1
 
-                cmpwi   interp_flag, 0          ; interp?
-                beq     cont                   ; no, goto compiled variant
+                cmpwi   interp_flag, 0          // interp?
+                beq     cont                   // no, goto compiled variant
 
-                import_data_address Temp1,processSemaphore; clear sema
+                import_data_address Temp1,processSemaphore// clear sema
                 li      r0, 0
                 stb     r0, 0(Temp1)
 
@@ -600,7 +600,7 @@ not_saved1:
                 blr
 
 cont: 
-                ; now load NLR params from globals
+                // now load NLR params from globals
 
                 import_data_address     Temp1,NLRResultFromC
                 lwz     NLRResultReg, 0(Temp1)
@@ -608,60 +608,60 @@ cont:
                 import_data_address     Temp1,NLRHomeIDFromC
                 lwz     NLRHomeIDReg, 0(Temp1)
 
-                import_data_address     Temp1,NLRHomeFromC; These two only needed if going back to self, just do anyway
+                import_data_address     Temp1,NLRHomeFromC// These two only needed if going back to self, just do anyway
                 lwz     NLRHomeReg, 0(Temp1)        
 
-                lwz     Temp1, LinkageArea_savedPC(sp) ; return
+                lwz     Temp1, LinkageArea_savedPC(sp) // return
                 addi    r0, Temp1, non_local_return_offset
-                mtlr    r0 ; return thru inline cache
+                mtlr    r0 // return thru inline cache
 
-                import_data_address Temp1,processSemaphore; clear sema
+                import_data_address Temp1,processSemaphore// clear sema
                 li      r0, 0
                 stb     r0, 0(Temp1)
 
                 blr
                       
                 
-; --------------------------------------------------------------
-; ContinueAfterReturnTrap
+// --------------------------------------------------------------
+// ContinueAfterReturnTrap
 
-; Note: we can simply restore nonvols by climing the stack,
-; only because we are not doing true conversions yet!.
-;
-; Is above still true? -- dmu 1/03
-; Maybe it works OK because of register locators.
+// Note: we can simply restore nonvols by climing the stack,
+// only because we are not doing true conversions yet!.
+//
+// Is above still true? -- dmu 1/03
+// Maybe it works OK because of register locators.
                 
-# define result_arg      arg0 ; note: is already in right place
+# define result_arg      arg0 // note: is already in right place
 # define pc_arg          arg1
 # define sp_arg          arg2
 
 
                 start_exported_function ContinueAfterReturnTrap
-                ; setup NLR regs
-    ; pop VM frames
-                import_function_address     Temp1,ReturnTrap_returnPC; get save stub return PC
+                // setup NLR regs
+    // pop VM frames
+                import_function_address     Temp1,ReturnTrap_returnPC// get save stub return PC
                 b       loop_entry_point1
                 
 notFound2:      lwz     r0, LinkageArea_savedPC(sp)
-                cmpw    r0, Temp1                         ; look for savenonvol frame
+                cmpw    r0, Temp1                         // look for savenonvol frame
                 bne+    not_saved2
-                lwz     Temp2, LinkageArea_savedSP(sp)  ; get top of savenonvol frame
+                lwz     Temp2, LinkageArea_savedSP(sp)  // get top of savenonvol frame
                 restore_local_nonvol_regs Temp2, 0
 not_saved2:
-                lwz     sp, LinkageArea_savedSP(sp)     ; pop frame
+                lwz     sp, LinkageArea_savedSP(sp)     // pop frame
 loop_entry_point1:                
                 cmpw    sp, sp_arg
                 bne     notFound2
 
-                import_data_address Temp1,processSemaphore; clear sema
+                import_data_address Temp1,processSemaphore// clear sema
                 li      r0, 0
                 stb     r0, 0(Temp1)
                 
-                mtlr    pc_arg ; goto pc
+                mtlr    pc_arg // goto pc
                 blr
                 
-; --------------------------------------------------------------
-; ContinueNLRAfterReturnTrap
+// --------------------------------------------------------------
+// ContinueNLRAfterReturnTrap
                 
 # undef pc_arg
 # define pc_arg          arg0
@@ -674,7 +674,7 @@ loop_entry_point1:
 
                 start_exported_function ContinueNLRAfterReturnTrap
                 
-                ; setup NLR regs
+                // setup NLR regs
                 
                 mr      Temp1,        pc_arg
                 mr      Temp2,        sp_arg
@@ -683,53 +683,53 @@ loop_entry_point1:
                 mr      NLRHomeIDReg, homeFrameID_arg
                 mr      r6, Temp1
                 mr      r7, Temp2
-                                        ; pop VM frames
-                import_function_address     Temp1,ReturnTrap_returnPC; get save stub return PC
+                                        // pop VM frames
+                import_function_address     Temp1,ReturnTrap_returnPC// get save stub return PC
                 b       loop_entry_point2
                 
 notFound3:      lwz     r0, LinkageArea_savedPC(sp)
-                cmpw    r0, Temp1                         ; look for savenonvol frame
+                cmpw    r0, Temp1                         // look for savenonvol frame
                 bne+    not_saved3
-                lwz     Temp2, LinkageArea_savedSP(sp)  ; get top of savenonvol frame
+                lwz     Temp2, LinkageArea_savedSP(sp)  // get top of savenonvol frame
                 restore_local_nonvol_regs Temp2, 0
 not_saved3:
-                lwz     sp, LinkageArea_savedSP(sp)     ; pop frame
+                lwz     sp, LinkageArea_savedSP(sp)     // pop frame
 loop_entry_point2:                
                 cmpw    sp, r7
                 bne     notFound3
                 
                                 
-                import_data_address Temp1,processSemaphore; clear sema
+                import_data_address Temp1,processSemaphore// clear sema
                 li      r0, 0
                 stb     r0, 0(Temp1)
                 
-                mtlr    r6 ; goto pc
+                mtlr    r6 // goto pc
                 blr
                 
- ; ---------------------------------------------------------
- ; SaveNVRet
+// ---------------------------------------------------------
+// SaveNVRet
 
- ; see comment in runtime.h or interpreter.h
- ;; Also known to RegisterLocator::update_addresses_from_VM_frame
+// see comment in runtime.h or interpreter.h
+/// Also known to RegisterLocator::update_addresses_from_VM_frame
 
 # define fn   arg5
 # define fnNo 5
 
- ; frame contains saved nonvols, room for callee to save all r3-r10 possible incoming reg args
- frsize =    LinkageArea_size + ((NumRcvrAndArgRegisters + NumNonVolRegisters) * size_of_gpr) ; will be saving all volatile registers + 2 for perform sel & del
- frsize =    round(frsize, alignment_of_sp); round up to quadword
+// frame contains saved nonvols, room for callee to save all r3-r10 possible incoming reg args
+ frsize =    LinkageArea_size + ((NumRcvrAndArgRegisters + NumNonVolRegisters) * size_of_gpr) // will be saving all volatile registers + 2 for perform sel & del
+ frsize =    round(frsize, alignment_of_sp)// round up to quadword
 
 
 start_exported_function SaveNVAndCall5
         
-                mflr    r0 ; save link
+                mflr    r0 // save link
                 stw     r0, LinkageArea_savedPC(sp)
-                stw     fn, (LinkageArea_size + (fnNo - arg0No) * size_of_gpr)(sp) ; save c entry point
+                stw     fn, (LinkageArea_size + (fnNo - arg0No) * size_of_gpr)(sp) // save c entry point
         
-                ; save nonvol gprs
+                // save nonvol gprs
                 stmw    LowestNonVolReg, -(size_of_gpr * NumNonVolRegisters)(sp)
-                stwu    sp, -frsize(sp) ; make frame
-                mtlr    fn ; goto fn
+                stwu    sp, -frsize(sp) // make frame
+                mtlr    fn // goto fn
                 blrl
         
 start_exported_function SaveNVRet // for stack-walking
@@ -739,15 +739,15 @@ start_exported_function SaveNVRet // for stack-walking
                 lwz     r0, LinkageArea_savedPC(sp)
                 mtlr    r0
                 blr
-; --------------------------------------------------------------
-; EnterSelf
+// --------------------------------------------------------------
+// EnterSelf
 
-; copied from CallPrimitiveFromInterpreter
+// copied from CallPrimitiveFromInterpreter
 
-; also need to export  firstSelfFrame_returnPC, firstSelfFrameSendDescEnd
+// also need to export  firstSelfFrame_returnPC, firstSelfFrameSendDescEnd
 
 
-  ; oop EnterSelf(oop recv, char* entryPoint, oop arg1)
+  // oop EnterSelf(oop recv, char* entryPoint, oop arg1)
 # define rcv_arg          arg0
 # define entry_point_arg  arg1
 # define arg1_arg         arg2  
@@ -759,12 +759,12 @@ fr_size          = round(LinkageArea_size  +  (outgoing_arg_count + NumGlobalNon
                   
 start_exported_function EnterSelf
                   
-                  ; save PC link
+                  // save PC link
                   
                   mflr     r0
-                  stw      r0, LinkageArea_savedPC(sp); save PC link (pc to return to)
+                  stw      r0, LinkageArea_savedPC(sp)// save PC link (pc to return to)
                   
-                  ; save global nonvols for C
+                  // save global nonvols for C
                   subi     Temp1, sp, NumGlobalNonVolRegisters * size_of_gpr
                   stswi    LowestNonVolReg, Temp1, NumGlobalNonVolRegisters * size_of_gpr
                   load_global_nonvol_regs
@@ -772,164 +772,164 @@ start_exported_function EnterSelf
                   stwu    sp, -fr_size(sp)
                   
                   
-                  ; call Self
+                  // call Self
                    
                   mtlr entry_point_arg
-                  ; dont need to move rcv
+                  // dont need to move rcv
                   mr   arg1, arg1_arg
                   
-                  ; Inline cache format: DUPLICATED in SendDesc, ReturnTrap
-                  blrl    ; go!
+                  // Inline cache format: DUPLICATED in SendDesc, ReturnTrap
+                  blrl    // go!
                   
-                  ; inline cache
+                  // inline cache
 start_exported_function firstSelfFrame_returnPC
                   b    send_desc_end               
-                  .long 0                       ; reg mask
+                  .long 0                       // reg mask
                   b    contNLR
-                  .long 0                       ; placeholder for nmlns
-                  .long 0                       ; placeholder for nmlns
-                  .long 0                       ; placeholder for selector
-                  .long 20                      ; placeholder for StaticNormalLookupType
+                  .long 0                       // placeholder for nmlns
+                  .long 0                       // placeholder for nmlns
+                  .long 0                       // placeholder for selector
+                  .long 20                      // placeholder for StaticNormalLookupType
                                   
 start_exported_function firstSelfFrameSendDescEnd
 send_desc_end:
                   lwz     sp,LinkageArea_savedSP(sp)
-                  ; restore global nonvols for C
+                  // restore global nonvols for C
                   subi    Temp1, sp, NumGlobalNonVolRegisters * size_of_gpr
                   lswi    LowestNonVolReg, Temp1, NumGlobalNonVolRegisters * size_of_gpr
                   lwz     r0,LinkageArea_savedPC(sp)
                   mtlr    r0
                   blr
 
-;        continue with NLR: prepare to call capture_NLR_parameters_from_registers with NLR reg params
+//        continue with NLR: prepare to call capture_NLR_parameters_from_registers with NLR reg params
 
 contNLR:          import_function_address     Temp1,capture_NLR_parameters_from_registers
                   mtlr    Temp1
                   
                   // don't need this because they are already in the right registers!
-                  ;mr      arg0, NLRResultReg
-                  ;mr      arg1, NLRHomeReg
-                  ;mr      arg2, NLRHomeIDReg
+                  //mr      arg0, NLRResultReg
+                  //mr      arg1, NLRHomeReg
+                  //mr      arg2, NLRHomeIDReg
                   blrl
                   
-                  ;; and back to caller (which is C code)
-                  b      send_desc_end ; restore stack & regs
+                  // and back to caller (which is C code)
+                  b      send_desc_end // restore stack & regs
                   
-; ====================================================================
+// ====================================================================
 
  
- ; SendMessage_stub: called from inline caches and prologue, post call, pre frame
- ; NonVols:
- ;   This routine goes via SaveSelfNonVolRegs because it calls out to C and C
- ;   may traverse the stack. This creates a coupling to RegisterLocator::update_addresses_from_VM_frame.
- ;   If that routine finds a frame for this stub, it can assume that all nonvols are stored
- ;   below its sp.
+// SendMessage_stub: called from inline caches and prologue, post call, pre frame
+// NonVols:
+//   This routine goes via SaveSelfNonVolRegs because it calls out to C and C
+//   may traverse the stack. This creates a coupling to RegisterLocator::update_addresses_from_VM_frame.
+//   If that routine finds a frame for this stub, it can assume that all nonvols are stored
+//   below its sp.
  
  
- num_outgoing_args = 6 ; I pass 6 args to C (SendMessage) so need to leave that much stack space
+ num_outgoing_args = 6 // I pass 6 args to C (SendMessage) so need to leave that much stack space
     
- ; I save args for the send here (DUPLICATED in runtime.h)
+// I save args for the send here (DUPLICATED in runtime.h)
  SendMessage_stub_volatile_register_sp_offset = LinkageArea_size/oopSize + num_outgoing_args
  
-; will be saving all volatile registers + 2 for perform sel & del
+// will be saving all volatile registers + 2 for perform sel & del
  frsize  = (SendMessage_stub_volatile_register_sp_offset + NumRcvrAndArgRegisters + 2 + NumLocalNonVolRegisters) * oopSize
 
- frsize = round(frsize, alignment_of_sp)    ; round up to quadword
+ frsize = round(frsize, alignment_of_sp)    // round up to quadword
    
                                
                 start_exported_function SendMessage_stub
-                 ; save link
+                 // save link
                  mflr    r0
                  stw     r0, LinkageArea_savedPC(sp)
                  save_local_nonvol_regs
    
-                 stwu sp, -frsize(sp)  ; create frame
+                 stwu sp, -frsize(sp)  // create frame
                  
-                 ; save volatile regs
+                 // save volatile regs
                  la    Temp1, (SendMessage_stub_volatile_register_sp_offset * oopSize)(sp)
                  stswi r3, Temp1, NumRcvrAndArgRegisters * oopSize 
                  
-                 ; setup args for SendMessage
+                 // setup args for SendMessage
                  
-                 ; NOTE: next few carefully ordered to avoid aliasing and destroying values
-                 ; and number of them must agree with no_outgoing_args above
+                 // NOTE: next few carefully ordered to avoid aliasing and destroying values
+                 // and number of them must agree with no_outgoing_args above
 
-                 mr     r8, r4; arg1
-                 lwz    r7, frsize + PerformDelegateeLoc_sp_offset (sp); these offsets are relative to sp when stub was entered
-                 lwz    r6, frsize + PerformSelectorLoc_sp_offset (sp); 
-                 mr     r5, r3; receiver    ; destroys arg2 but we dont need arg2             
-                 la     r4, frsize(sp);  lookup frame
-                 mflr   r3; ; REUSING LINK VALUE for sendDesc arg
+                 mr     r8, r4// arg1
+                 lwz    r7, frsize + PerformDelegateeLoc_sp_offset (sp)// these offsets are relative to sp when stub was entered
+                 lwz    r6, frsize + PerformSelectorLoc_sp_offset (sp)// 
+                 mr     r5, r3// receiver    // destroys arg2 but we dont need arg2             
+                 la     r4, frsize(sp)//  lookup frame
+                 mflr   r3// // REUSING LINK VALUE for sendDesc arg
                  
                  import_function_address    Temp1,SendMessage
                  mtlr   Temp1
                  blrl
                  
-                 ; returns entry point, use count register so orig link can be in link reg
+                 // returns entry point, use count register so orig link can be in link reg
                  
 start_exported_function SendMessage_stub_returnPC // for stack-walking
                  mtctr  result
                  
-                 ; now restore everything:
-                 ; first vol regs
+                 // now restore everything:
+                 // first vol regs
                  la    Temp1, (SendMessage_stub_volatile_register_sp_offset * oopSize)(sp)
                  lswi  r3, Temp1, NumRcvrAndArgRegisters * oopSize
                  
-                 la    sp, frsize(sp);  restore sp
+                 la    sp, frsize(sp)//  restore sp
                  restore_local_nonvol_regs sp, 0
-                 lwz  r0, LinkageArea_savedPC(sp);  restore link
+                 lwz  r0, LinkageArea_savedPC(sp)//  restore link
                  mtlr  r0
                  
-                 bctr;  branch to counter reg
+                 bctr//  branch to counter reg
                  
-; ======================================================================================                   
+// ======================================================================================                   
 
  
- ; SendDIMessage_stub: called from inline caches and prologue, post call, pre frame
- ; NonVols:
- ;   This routine goes via SaveSelfNonVolRegs because it calls out to C and C
- ;   may traverse the stack. This creates a coupling to RegisterLocator::update_addresses_from_VM_frame.
- ;   If that routine finds a frame for this stub, it can assume that all nonvols are stored
- ;   below its sp.
+// SendDIMessage_stub: called from inline caches and prologue, post call, pre frame
+// NonVols:
+//   This routine goes via SaveSelfNonVolRegs because it calls out to C and C
+//   may traverse the stack. This creates a coupling to RegisterLocator::update_addresses_from_VM_frame.
+//   If that routine finds a frame for this stub, it can assume that all nonvols are stored
+//   below its sp.
  
- ; To make the profiler work we save the link register in the stack frame. -- dmu 2/04
+// To make the profiler work we save the link register in the stack frame. -- dmu 2/04
  
- num_outgoing_args = 6 ; I pass 6 args to C (SendDIMessage) so need to leave that much stack space
+ num_outgoing_args = 6 // I pass 6 args to C (SendDIMessage) so need to leave that much stack space
     
- ; I save args for the send here (DUPLICATED in runtime.h)
+// I save args for the send here (DUPLICATED in runtime.h)
  SendDIMessage_stub_volatile_register_sp_offset = LinkageArea_size/oopSize + num_outgoing_args
  
- frsize = (SendDIMessage_stub_volatile_register_sp_offset + NumRcvrAndArgRegisters + 2 + NumLocalNonVolRegisters) * oopSize ; will be saving all volatile registers + 2 for perform sel & del
- frsize = round(frsize, alignment_of_sp)    ; round up to quadword
+ frsize = (SendDIMessage_stub_volatile_register_sp_offset + NumRcvrAndArgRegisters + 2 + NumLocalNonVolRegisters) * oopSize // will be saving all volatile registers + 2 for perform sel & del
+ frsize = round(frsize, alignment_of_sp)    // round up to quadword
    
 start_exported_function SendDIMessage_stub
                 
-                 // ; (Note caller's link is passed in in DILinkReg)
+                 // // (Note caller's link is passed in in DILinkReg)
                  save_local_nonvol_regs
                  
-                 // ; save PC of caller in his stack frame so that profiler can set last_frame to one above
-                 // ; interrupted context's sp. One stwu below sets sp, profiler will count on  LinkageArea_savedPC(sp) -- dmu 2/04
+                 // // save PC of caller in his stack frame so that profiler can set last_frame to one above
+                 // // interrupted context's sp. One stwu below sets sp, profiler will count on  LinkageArea_savedPC(sp) -- dmu 2/04
                  mflr    r0
                  stw     r0, LinkageArea_savedPC(sp)
                  
-                 stwu sp, -frsize(sp)  ; create frame
+                 stwu sp, -frsize(sp)  // create frame
                  
-                 // ; save volatile regs
+                 // // save volatile regs
                  la    DITempReg, (SendDIMessage_stub_volatile_register_sp_offset * oopSize)(sp)
                  stswi r3, DITempReg, NumRcvrAndArgRegisters * oopSize
                  
-                 ; setup args for SendDIMessage
+                 // setup args for SendDIMessage
                  
-                 ; NOTE: next few carefully ordered to avoid aliasing and destroying values
-                 ; and number of them must agree with no_outgoing_args above
+                 // NOTE: next few carefully ordered to avoid aliasing and destroying values
+                 // and number of them must agree with no_outgoing_args above
 
-                 mr     r8, r4; arg1
-                 mr     r7, r3; rcvr
-                 mr     r6, DICountReg; r0
-                 mr     r5, DILinkReg; points right to the nmln and after the call
-                 la     r4, frsize(sp);  lookup frame
+                 mr     r8, r4// arg1
+                 mr     r7, r3// rcvr
+                 mr     r6, DICountReg// r0
+                 mr     r5, DILinkReg// points right to the nmln and after the call
+                 la     r4, frsize(sp)//  lookup frame
                  mflr   r3  // send desc: use caller's link
-                 stw    r3, LinkageArea_savedPC + frsize(sp); and save link for stack crawling
+                 stw    r3, LinkageArea_savedPC + frsize(sp)// and save link for stack crawling
                  
                  //  ahh... through with DI*Reg's
                
@@ -937,128 +937,128 @@ start_exported_function SendDIMessage_stub
                  mtlr   Temp1
                  blrl
                  
-                 ; returns entry point, use count register so orig link can be in link reg
+                 // returns entry point, use count register so orig link can be in link reg
                  
 start_exported_function SendDIMessage_stub_returnPC // for stack-walking
                  mtctr  result
                  
-                 ; now restore everything:
-                 ; first vol regs
+                 // now restore everything:
+                 // first vol regs
                  la    Temp1, (SendDIMessage_stub_volatile_register_sp_offset * oopSize)(sp)
                  lswi  r3, Temp1, NumRcvrAndArgRegisters * oopSize
                  
-                 la    sp, frsize(sp);  restore sp
+                 la    sp, frsize(sp)//  restore sp
                  restore_local_nonvol_regs sp, 0
-                 lwz   r0, LinkageArea_savedPC(sp);  restore link
+                 lwz   r0, LinkageArea_savedPC(sp)//  restore link
                  mtlr  r0
                  
-                 bctr;  branch to counter reg
+                 bctr//  branch to counter reg
                  
-; ======================================================================================                   
+// ======================================================================================                   
 
 
 
 
-; MakeOld_stub
-; called when a young nmethod''s counter overflows.
-; called by a count stub.
+// MakeOld_stub
+// called when a young nmethod''s counter overflows.
+// called by a count stub.
 
-; The bit with might need _Perform selector...
-; What if a method being called when MakeOld/Recompile is called
-; is being _Performed? Might need to save these two. -- dmu 2/03
+// The bit with might need _Perform selector...
+// What if a method being called when MakeOld/Recompile is called
+// is being _Performed? Might need to save these two. -- dmu 2/03
 
- num_outgoing_args = 5 ; I pass 5 args to C (MakeOld) so need to leave that much stack space
+ num_outgoing_args = 5 // I pass 5 args to C (MakeOld) so need to leave that much stack space
     
  MakeOld_stub_volatile_register_sp_offset = LinkageArea_size/oopSize + num_outgoing_args
  
  frsize  = (MakeOld_stub_volatile_register_sp_offset + NumRcvrAndArgRegisters + NumLocalNonVolRegisters + 2 /* might need _Perform selector & del */) * oopSize
 
- frsize = round(frsize, alignment_of_sp)    ; round up to quadword
+ frsize = round(frsize, alignment_of_sp)    // round up to quadword
 
 start_exported_function MakeOld_stub
-                 // ; (Note caller's link is passed in in RecompileLinkReg)
+                 // // (Note caller's link is passed in in RecompileLinkReg)
                  save_local_nonvol_regs
-                 stwu sp, -frsize(sp)  ; create frame (link reg was already saved in CountCodePattern::initComparing())
+                 stwu sp, -frsize(sp)  // create frame (link reg was already saved in CountCodePattern::initComparing())
                  
-                 ; save volatile regs
+                 // save volatile regs
                  la    RecompileTempReg, (MakeOld_stub_volatile_register_sp_offset * oopSize)(sp)
                  stswi r3, RecompileTempReg, NumRcvrAndArgRegisters * oopSize
                  
-                 ; setup args for MakeOld
+                 // setup args for MakeOld
                  
-                 mr     r7, RecompileLinkReg ; nmethod/stub calling us
-                 li     r6, 0                ; no DI
-                 mr     r5, r3               ; receiver
-                 la     r4, frsize(sp)       ; lookup frame
-                 mflr   r3                   ; send desc: use caller''s link
-                 stw    r3, LinkageArea_savedPC + frsize(sp); and save link for stack crawling
+                 mr     r7, RecompileLinkReg // nmethod/stub calling us
+                 li     r6, 0                // no DI
+                 mr     r5, r3               // receiver
+                 la     r4, frsize(sp)       // lookup frame
+                 mflr   r3                   // send desc: use caller''s link
+                 stw    r3, LinkageArea_savedPC + frsize(sp)// and save link for stack crawling
                  
-                 ; will be calling MakeOld, but save non vols on the way
+                 // will be calling MakeOld, but save non vols on the way
                  import_function_address    Temp1,MakeOld
                  mtlr   Temp1
                  blrl
                  
-                 ; returns entry point, use count register so orig link can be in link reg
+                 // returns entry point, use count register so orig link can be in link reg
   
 start_exported_function MakeOld_stub_returnPC // for stack-walking
                  mtctr  result
   
-                 ; now restore everything:
-                 ; first vol regs
+                 // now restore everything:
+                 // first vol regs
                  la    Temp1, (MakeOld_stub_volatile_register_sp_offset * oopSize)(sp)
                  lswi  r3, Temp1, NumRcvrAndArgRegisters * oopSize
                  
-                 la    sp, frsize(sp);  restore sp
+                 la    sp, frsize(sp)//  restore sp
                  restore_local_nonvol_regs sp, 0
-                 lwz   r0, LinkageArea_savedPC(sp);  restore link
+                 lwz   r0, LinkageArea_savedPC(sp)//  restore link
                  mtlr  r0
   
-                 bctr;  branch to counter reg
+                 bctr//  branch to counter reg
 
   
-; ======================================================================================  
+// ======================================================================================  
 
 
 
-; ReturnTrap: return pointer is patched to me. I save registers and
-; call HandleReturnTrap. Must look like an inline cache.
-; Well, actually this may not be strictly necessary, but it guards
-; against misusing the ret pc.
+// ReturnTrap: return pointer is patched to me. I save registers and
+// call HandleReturnTrap. Must look like an inline cache.
+// Well, actually this may not be strictly necessary, but it guards
+// against misusing the ret pc.
 
-; Also for PPC, PrimCallReturnTrap is the same
+// Also for PPC, PrimCallReturnTrap is the same
 
 
 HandleReturnTrap_arg_count = 5
 
 frsize = (LinkageArea_size/oopSize + HandleReturnTrap_arg_count + NumLocalNonVolRegisters) * oopSize
-; DUPLICATED in frame_format_ppc.hh
+// DUPLICATED in frame_format_ppc.hh
 ReturnTrap_frame_size = round(frsize, alignment_of_sp)
 
 start_exported_function ReturnTrap_start
 
-                  .long 0                       ; placeholder for call instruction
+                  .long 0                       // placeholder for call instruction
 start_exported_function ReturnTrap
 start_exported_function PrimCallReturnTrap          
                   b    rt2               
-                  .long 0                       ; reg mask
+                  .long 0                       // reg mask
                   b    ReturnTrap_beyond_for_NLR
-                  .long 0                       ; placeholder for nmlns
-                  .long 0                       ; placeholder for nmlns
-                  .long 0                       ; placeholder for selector
-                  .long 0                       ; placeholder for lookup type
-                  .long 0                       ; placeholder for delegatee
+                  .long 0                       // placeholder for nmlns
+                  .long 0                       // placeholder for nmlns
+                  .long 0                       // placeholder for selector
+                  .long 0                       // placeholder for lookup type
+                  .long 0                       // placeholder for delegatee
 
 start_exported_function ReturnTrap2  
 rt2:                     
-                 ; result already in r3
+                 // result already in r3
                  mr     arg1, sp
-                 li     arg2, 0 ; not NLR
+                 li     arg2, 0 // not NLR
                  li     arg3, 0 
                  li     arg4, 0
                  
 ReturnTrap_do_call:          
                  save_local_nonvol_regs
-                 ; (link must already be saved since this is a return trap -- dmu 2/04)
+                 // (link must already be saved since this is a return trap -- dmu 2/04)
                  stwu   sp, -ReturnTrap_frame_size(sp)
                  
 import_function_address    Temp1,HandleReturnTrap
@@ -1066,27 +1066,27 @@ import_function_address    Temp1,HandleReturnTrap
                  blrl
                  
 start_exported_function ReturnTrap_returnPC
-start_exported_function ReturnTrapNLR_returnPC ; SPARC needs both, same for PPC
-                 .long   0 ; no return
+start_exported_function ReturnTrapNLR_returnPC // SPARC needs both, same for PPC
+                 .long   0 // no return
                  
 ReturnTrap_beyond_for_NLR: 
-                 ; WARNING: carefully ordered to avoid clobbering values
+                 // WARNING: carefully ordered to avoid clobbering values
                  mr     r7, NLRHomeIDReg
                  mr     r6, NLRHomeReg
-                 li     r5, 1 ;  NLR
+                 li     r5, 1 //  NLR
                  mr     r4, sp
-                 ; result already in r3 WARNING: assumes NLRResultReg = r3
+                 // result already in r3 WARNING: assumes NLRResultReg = r3
                 
                  b      ReturnTrap_do_call
  
-; ======================================================================================  
+// ======================================================================================  
 
 
 
-; ProfilerTrap: return pointer is patched to me. I save registers and
-; call HandleProfilerTrap. Must look like an inline cache.
-; Well, actually this may not be strictly necessary, but it guards
-; against misusing the ret pc.
+// ProfilerTrap: return pointer is patched to me. I save registers and
+// call HandleProfilerTrap. Must look like an inline cache.
+// Well, actually this may not be strictly necessary, but it guards
+// against misusing the ret pc.
 
 
 
@@ -1095,35 +1095,35 @@ HandleProfilerTrap_arg_count = 1
 ProfilerTrap_volatile_register_sp_offset = LinkageArea_size/oopSize + HandleProfilerTrap_arg_count
 
 
-numVolRegsToSave = HandleProfilerTrap_arg_count ; could someday be NumNLRRegisters
+numVolRegsToSave = HandleProfilerTrap_arg_count // could someday be NumNLRRegisters
 
 
 frsize = (ProfilerTrap_volatile_register_sp_offset + numVolRegsToSave + HandleProfilerTrap_arg_count + NumLocalNonVolRegisters) * oopSize
-; DUPLICATED in frame_format_ppc.hh
+// DUPLICATED in frame_format_ppc.hh
 ProfilerTrap_frame_size = round(frsize, alignment_of_sp)
 
 start_exported_function ProfilerTrap_start
 
-                  .long 0                       ; placeholder for call instruction
+                  .long 0                       // placeholder for call instruction
 start_exported_function ProfilerTrap
                   b    pf2               
-                  .long 0                       ; reg mask
+                  .long 0                       // reg mask
                   b    returnProfilerNLR
-                  .long 0                       ; placeholder for nmlns
-                  .long 0                       ; placeholder for nmlns
-                  .long 0                       ; placeholder for selector
-                  .long 0                       ; placeholder for lookup type
-                  .long 0                       ; placeholder for delegatee
+                  .long 0                       // placeholder for nmlns
+                  .long 0                       // placeholder for nmlns
+                  .long 0                       // placeholder for selector
+                  .long 0                       // placeholder for lookup type
+                  .long 0                       // placeholder for delegatee
 
 pf2:                     
-                 lwz   Temp2, current_pc_offset(sp);  get return address
+                 lwz   Temp2, current_pc_offset(sp)//  get return address
 
                  save_local_nonvol_regs
                  stwu   sp, -ProfilerTrap_frame_size(sp)
 
-                 ; (link must already be saved since this is a return trap -- dmu 2/04)
+                 // (link must already be saved since this is a return trap -- dmu 2/04)
                  
-                 ; save NLR (volatile) regs
+                 // save NLR (volatile) regs
                  la Temp1, (ProfilerTrap_volatile_register_sp_offset * oopSize)(sp)
                  stswi arg0 /* also normal result reg */,Temp1,  numVolRegsToSave * oopSize
                  mr    arg0, Temp2
@@ -1142,16 +1142,16 @@ import_function_address    Temp1,HandleProfilerTrap
                  blr
                  
 returnProfilerNLR:
-; just continue NLR                 
-                lwz   Temp1, current_pc_offset(sp);  get return address
+// just continue NLR                 
+                lwz   Temp1, current_pc_offset(sp)//  get return address
                 addi  Temp1, Temp1, non_local_return_offset
                 mtlr  Temp1
                 blr
 
-; ==============================
+// ==============================
 
 
-/* Doesn't seem to work; use Carbonosity instead
+/* Doesn't seem to work// use Carbonosity instead
 
 start_exported_function FlushInstruction
       icbi 0, r3
@@ -1159,7 +1159,7 @@ start_exported_function FlushInstruction
       blr
 */
 
-; =========================================
+// =========================================
 
 // implement write system call lib routine
 
@@ -1172,68 +1172,68 @@ start_exported_function WRITE
 */
 
 
-;;; warning: following code is untested; it is modelled after SendDIMessage_stub
+//// warning: following code is untested// it is modelled after SendDIMessage_stub
 
-; ====================================================================
- ; Recompile_stub: called when a normal method''s counter overflows.  called by a 
- ; NIC nmethod or PIC.  caller must store its link register (which contains the
- ; sendDesc) into Temp2 AND save it on the frame.  it must then jump AND link to us, 
- ; so that the link register contains the nmethod/stub.  see CodeGen::checkRecompilation.
- ; it's ugly but i couldn't find a better way.    -mabdelmalek 12/02
- ; see comment on SendMessage_stub on why we save the non-volatile registers
+// ====================================================================
+// Recompile_stub: called when a normal method''s counter overflows.  called by a 
+// NIC nmethod or PIC.  caller must store its link register (which contains the
+// sendDesc) into Temp2 AND save it on the frame.  it must then jump AND link to us, 
+// so that the link register contains the nmethod/stub.  see CodeGen::checkRecompilation.
+// it's ugly but i couldn't find a better way.    -mabdelmalek 12/02
+// see comment on SendMessage_stub on why we save the non-volatile registers
  
- num_outgoing_args = 5 ; I pass 5 args to C (Recompile) so need to leave that much stack space
+ num_outgoing_args = 5 // I pass 5 args to C (Recompile) so need to leave that much stack space
     
  Recompile_stub_volatile_register_sp_offset = LinkageArea_size/oopSize + num_outgoing_args
  
  frsize  = (Recompile_stub_volatile_register_sp_offset + NumRcvrAndArgRegisters + NumLocalNonVolRegisters + 2 /* might need _Perform selector & del */) * oopSize
 
- frsize = round(frsize, alignment_of_sp)    ; round up to quadword
+ frsize = round(frsize, alignment_of_sp)    // round up to quadword
   
                                
 start_exported_function Recompile_stub
-                 // ; (Note caller's link is passed in in RecompileLinkReg)
+                 // // (Note caller's link is passed in in RecompileLinkReg)
   
                  save_local_nonvol_regs
                  
-                 ; link already saved (for profiler, see comment above)
+                 // link already saved (for profiler, see comment above)
 
-                 stwu sp, -frsize(sp)  ; create frame
+                 stwu sp, -frsize(sp)  // create frame
                  
-                 ; save volatile regs
+                 // save volatile regs
                  la    RecompileTempReg, (Recompile_stub_volatile_register_sp_offset * oopSize)(sp)
                  stswi r3, RecompileTempReg, NumRcvrAndArgRegisters * oopSize
                  
-                 ; setup args for Recompile
+                 // setup args for Recompile
                  
-                 mr     r7, RecompileLinkReg ; nmethod/stub calling us
-                 li     r6, 0                ; no DI
-                 mr     r5, r3               ; receiver
-                 la     r4, frsize(sp)       ; lookup frame
-                 mflr   r3                   ; send desc: use caller''s link
-                 stw    r3, LinkageArea_savedPC + frsize(sp); and save link for stack crawling
+                 mr     r7, RecompileLinkReg // nmethod/stub calling us
+                 li     r6, 0                // no DI
+                 mr     r5, r3               // receiver
+                 la     r4, frsize(sp)       // lookup frame
+                 mflr   r3                   // send desc: use caller''s link
+                 stw    r3, LinkageArea_savedPC + frsize(sp)// and save link for stack crawling
                  
-                 ; will be calling Recompile, but save non vols on the way
+                 // will be calling Recompile, but save non vols on the way
                  import_function_address    Temp1,Recompile
                  mtlr   Temp1
                  blrl
                  
-                 ; returns entry point, use count register so orig link can be in link reg
+                 // returns entry point, use count register so orig link can be in link reg
                  
 start_exported_function Recompile_stub_returnPC // for stack-walking
                  mtctr  result
                  
-                 ; now restore everything:
-                 ; first vol regs
+                 // now restore everything:
+                 // first vol regs
                  la    Temp1, (Recompile_stub_volatile_register_sp_offset * oopSize)(sp)
                  lswi  r3, Temp1, NumRcvrAndArgRegisters * oopSize
                  
-                 la    sp, frsize(sp);  restore sp
-                 lwz   r0, LinkageArea_savedPC(sp);  restore link
+                 la    sp, frsize(sp)//  restore sp
+                 lwz   r0, LinkageArea_savedPC(sp)//  restore link
                  restore_local_nonvol_regs sp, 0
                  mtlr  r0
                  
-                 bctr;  branch to counter reg
+                 bctr//  branch to counter reg
                  
                  
                                   

--- a/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
+++ b/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
@@ -11,23 +11,23 @@
 
 # include "asmDefs_gcc_ppc.hh"
         
-    start_exported_function currentFrame
+    start_exported_function(currentFrame)
     mr     r3, sp
     blr
 
-    start_exported_function currentRTOC
+    start_exported_function(currentRTOC)
     mr     r3, rtoc
     blr
 
-    start_exported_function currentReturnAddr
+    start_exported_function(currentReturnAddr)
     lwz    r3, LinkageArea_savedPC(sp)
     blr
 
-    start_exported_function set_SPLimitReg
+    start_exported_function(set_SPLimitReg)
     mr   SPLimitReg, r3 // relies on C not using this register (ugh)
     blr
 
-    start_exported_function save1Arg
+    start_exported_function(save1Arg)
     // save arg1 in stack frame
     stw    r3, LinkageArea_size(sp) // arg area is right after linkage area
     blr
@@ -115,7 +115,7 @@ saveAddr_PC = size_of_gpr
   
 // first make new stack frame & save all registers in it
 
-start_exported_function SetSPAndCall
+start_exported_function(SetSPAndCall)
         mflr    link
         stw     link, LinkageArea_savedPC(sp)
         mfcr    r0
@@ -294,7 +294,7 @@ SwSFrame_top = round(SwSFrame_argsave  +  4 * size_of_gpr, alignment_of_sp)
 SwSFrame_size = SwSFrame_top
 
 
-start_exported_function SwitchStack0 
+start_exported_function(SwitchStack0) 
 switch_stack: 
         mflr    r0
         stw     r0, LinkageArea_savedPC(sp)
@@ -317,16 +317,16 @@ switch_stack:
         blr     
 
 
-  start_exported_function SwitchStack1
+  start_exported_function(SwitchStack1)
         b switch_stack
 
-  start_exported_function SwitchStack2
+  start_exported_function(SwitchStack2)
         b switch_stack
 
-  start_exported_function SwitchStack3
+  start_exported_function(SwitchStack3)
         b switch_stack
 
-  start_exported_function SwitchStack4
+  start_exported_function(SwitchStack4)
         b switch_stack
         
         
@@ -359,7 +359,7 @@ linkage_len     = 12
 # define arg_count       r30
 # define scr_b           r29
 
-  start_exported_function CallPrimitiveFromInterpreter
+  start_exported_function(CallPrimitiveFromInterpreter)
   
         mflr    r0
         stw     r0,LinkageArea_savedPC(sp) // save link
@@ -482,7 +482,7 @@ base_fr_size =   LinkageArea_size/oopSize + NumRcvrAndArgRegisters + -SaveSelfNo
                 lmw     LowestLocalNonVolReg, ($1 -(size_of_gpr * NumLocalNonVolRegisters))($0)
                 .endmacro
                 
-                start_exported_function SaveSelfNonVolRegs        
+                start_exported_function(SaveSelfNonVolRegs)        
 SaveSelfNonVolRegs_start:
                 mflr    r0 // save link
                 stw     r0, LinkageArea_savedPC(sp)
@@ -507,7 +507,7 @@ do_call:
                 mtlr    SaveSelfNonVolRegs_entry_point_register
                 blrl
                 
-start_exported_function SaveSelfNonVolRegs_returnPC
+start_exported_function(SaveSelfNonVolRegs_returnPC)
                 b       return_normally
                 .long    0 // mask
                 b       return_nlr
@@ -573,7 +573,7 @@ do_another:     lwzu    r0, size_of_gpr(srcp)
 # define self_ic_flag    arg2 // called from Self ic?
         
 
-start_exported_function ContinueNLRFromC    // called by VM 
+start_exported_function(ContinueNLRFromC)    // called by VM 
                 // pop VM frames
                 import_function_address     Temp1,SaveSelfNonVolRegs_returnPC// get save stub return PC
                  b       skipFirstPop
@@ -636,7 +636,7 @@ cont:
 # define sp_arg          arg2
 
 
-                start_exported_function ContinueAfterReturnTrap
+                start_exported_function(ContinueAfterReturnTrap)
                 // setup NLR regs
     // pop VM frames
                 import_function_address     Temp1,ReturnTrap_returnPC// get save stub return PC
@@ -672,7 +672,7 @@ loop_entry_point1:
 # define homeFrame_arg   arg3
 # define homeFrameID_arg arg4    
 
-                start_exported_function ContinueNLRAfterReturnTrap
+                start_exported_function(ContinueNLRAfterReturnTrap)
                 
                 // setup NLR regs
                 
@@ -720,7 +720,7 @@ loop_entry_point2:
  frsize =    round(frsize, alignment_of_sp)// round up to quadword
 
 
-start_exported_function SaveNVAndCall5
+start_exported_function(SaveNVAndCall5)
         
                 mflr    r0 // save link
                 stw     r0, LinkageArea_savedPC(sp)
@@ -732,7 +732,7 @@ start_exported_function SaveNVAndCall5
                 mtlr    fn // goto fn
                 blrl
         
-start_exported_function SaveNVRet // for stack-walking
+start_exported_function(SaveNVRet) // for stack-walking
                 lwz     sp, 0(sp)
                 lmw     LowestNonVolReg, -(size_of_gpr * NumNonVolRegisters)(sp)
         
@@ -757,7 +757,7 @@ fr_size          = round(LinkageArea_size  +  (outgoing_arg_count + NumGlobalNon
                 
  
                   
-start_exported_function EnterSelf
+start_exported_function(EnterSelf)
                   
                   // save PC link
                   
@@ -782,7 +782,7 @@ start_exported_function EnterSelf
                   blrl    // go!
                   
                   // inline cache
-start_exported_function firstSelfFrame_returnPC
+start_exported_function(firstSelfFrame_returnPC)
                   b    send_desc_end               
                   .long 0                       // reg mask
                   b    contNLR
@@ -791,7 +791,7 @@ start_exported_function firstSelfFrame_returnPC
                   .long 0                       // placeholder for selector
                   .long 20                      // placeholder for StaticNormalLookupType
                                   
-start_exported_function firstSelfFrameSendDescEnd
+start_exported_function(firstSelfFrameSendDescEnd)
 send_desc_end:
                   lwz     sp,LinkageArea_savedSP(sp)
                   // restore global nonvols for C
@@ -837,7 +837,7 @@ contNLR:          import_function_address     Temp1,capture_NLR_parameters_from_
  frsize = round(frsize, alignment_of_sp)    // round up to quadword
    
                                
-                start_exported_function SendMessage_stub
+                start_exported_function(SendMessage_stub)
                  // save link
                  mflr    r0
                  stw     r0, LinkageArea_savedPC(sp)
@@ -867,7 +867,7 @@ contNLR:          import_function_address     Temp1,capture_NLR_parameters_from_
                  
                  // returns entry point, use count register so orig link can be in link reg
                  
-start_exported_function SendMessage_stub_returnPC // for stack-walking
+start_exported_function(SendMessage_stub_returnPC) // for stack-walking
                  mtctr  result
                  
                  // now restore everything:
@@ -902,7 +902,7 @@ start_exported_function SendMessage_stub_returnPC // for stack-walking
  frsize = (SendDIMessage_stub_volatile_register_sp_offset + NumRcvrAndArgRegisters + 2 + NumLocalNonVolRegisters) * oopSize // will be saving all volatile registers + 2 for perform sel & del
  frsize = round(frsize, alignment_of_sp)    // round up to quadword
    
-start_exported_function SendDIMessage_stub
+start_exported_function(SendDIMessage_stub)
                 
                  // // (Note caller's link is passed in in DILinkReg)
                  save_local_nonvol_regs
@@ -939,7 +939,7 @@ start_exported_function SendDIMessage_stub
                  
                  // returns entry point, use count register so orig link can be in link reg
                  
-start_exported_function SendDIMessage_stub_returnPC // for stack-walking
+start_exported_function(SendDIMessage_stub_returnPC) // for stack-walking
                  mtctr  result
                  
                  // now restore everything:
@@ -975,7 +975,7 @@ start_exported_function SendDIMessage_stub_returnPC // for stack-walking
 
  frsize = round(frsize, alignment_of_sp)    // round up to quadword
 
-start_exported_function MakeOld_stub
+start_exported_function(MakeOld_stub)
                  // // (Note caller's link is passed in in RecompileLinkReg)
                  save_local_nonvol_regs
                  stwu sp, -frsize(sp)  // create frame (link reg was already saved in CountCodePattern::initComparing())
@@ -1000,7 +1000,7 @@ start_exported_function MakeOld_stub
                  
                  // returns entry point, use count register so orig link can be in link reg
   
-start_exported_function MakeOld_stub_returnPC // for stack-walking
+start_exported_function(MakeOld_stub_returnPC) // for stack-walking
                  mtctr  result
   
                  // now restore everything:
@@ -1034,11 +1034,11 @@ frsize = (LinkageArea_size/oopSize + HandleReturnTrap_arg_count + NumLocalNonVol
 // DUPLICATED in frame_format_ppc.hh
 ReturnTrap_frame_size = round(frsize, alignment_of_sp)
 
-start_exported_function ReturnTrap_start
+start_exported_function(ReturnTrap_start)
 
                   .long 0                       // placeholder for call instruction
-start_exported_function ReturnTrap
-start_exported_function PrimCallReturnTrap          
+start_exported_function(ReturnTrap)
+start_exported_function(PrimCallReturnTrap)          
                   b    rt2               
                   .long 0                       // reg mask
                   b    ReturnTrap_beyond_for_NLR
@@ -1048,7 +1048,7 @@ start_exported_function PrimCallReturnTrap
                   .long 0                       // placeholder for lookup type
                   .long 0                       // placeholder for delegatee
 
-start_exported_function ReturnTrap2  
+start_exported_function(ReturnTrap2)  
 rt2:                     
                  // result already in r3
                  mr     arg1, sp
@@ -1065,8 +1065,8 @@ import_function_address    Temp1,HandleReturnTrap
                  mtlr   Temp1
                  blrl
                  
-start_exported_function ReturnTrap_returnPC
-start_exported_function ReturnTrapNLR_returnPC // SPARC needs both, same for PPC
+start_exported_function(ReturnTrap_returnPC)
+start_exported_function(ReturnTrapNLR_returnPC) // SPARC needs both, same for PPC
                  .long   0 // no return
                  
 ReturnTrap_beyond_for_NLR: 
@@ -1102,10 +1102,10 @@ frsize = (ProfilerTrap_volatile_register_sp_offset + numVolRegsToSave + HandlePr
 // DUPLICATED in frame_format_ppc.hh
 ProfilerTrap_frame_size = round(frsize, alignment_of_sp)
 
-start_exported_function ProfilerTrap_start
+start_exported_function(ProfilerTrap_start)
 
                   .long 0                       // placeholder for call instruction
-start_exported_function ProfilerTrap
+start_exported_function(ProfilerTrap)
                   b    pf2               
                   .long 0                       // reg mask
                   b    returnProfilerNLR
@@ -1153,7 +1153,7 @@ returnProfilerNLR:
 
 /* Doesn't seem to work// use Carbonosity instead
 
-start_exported_function FlushInstruction
+start_exported_function(FlushInstruction)
       icbi 0, r3
       isync
       blr
@@ -1164,7 +1164,7 @@ start_exported_function FlushInstruction
 // implement write system call lib routine
 
 /*
-start_exported_function WRITE
+start_exported_function(WRITE)
   li r0, 4
    sc
   blr
@@ -1191,7 +1191,7 @@ start_exported_function WRITE
  frsize = round(frsize, alignment_of_sp)    // round up to quadword
   
                                
-start_exported_function Recompile_stub
+start_exported_function(Recompile_stub)
                  // // (Note caller's link is passed in in RecompileLinkReg)
   
                  save_local_nonvol_regs
@@ -1220,7 +1220,7 @@ start_exported_function Recompile_stub
                  
                  // returns entry point, use count register so orig link can be in link reg
                  
-start_exported_function Recompile_stub_returnPC // for stack-walking
+start_exported_function(Recompile_stub_returnPC) // for stack-walking
                  mtctr  result
                  
                  // now restore everything:
@@ -1237,7 +1237,7 @@ start_exported_function Recompile_stub_returnPC // for stack-walking
                  
                  
                                   
-start_exported_function swap_bytes
+start_exported_function(swap_bytes)
   lwz    r4, 0(r3)
   stwbrx r4, 0, r3
   blr

--- a/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
+++ b/vm/src/ppc/runtime/runtime_asm_gcc_ppc.S
@@ -231,7 +231,7 @@ firstTimeThisProcess:
         andc    sp,sp,r0 // align by 16
         li      r0, 0
         stwu    r0, LinkageArea_savedSP - FirstFrame_size(sp)      // decr & store null sp
-        import_function_address r3,ReturnOffTopOfProcess
+        import_function_address(r3, ReturnOffTopOfProcess)
         stw     r3,LinkageArea_savedPC(sp)
         
         # if GENERATE_DEBUGGING_AIDS
@@ -465,8 +465,8 @@ base_fr_size =   LinkageArea_size/oopSize + NumRcvrAndArgRegisters + -SaveSelfNo
 
 
                 .macro load_global_nonvol_regs
-                import_data_address     ByteMapBaseReg,byte_map_base
-                import_data_address     SPLimitReg,SPLimit
+                import_data_address(ByteMapBaseReg, byte_map_base)
+                import_data_address(SPLimitReg, SPLimit)
                 lwz     ByteMapBaseReg, 0(ByteMapBaseReg)
                 lwz     SPLimitReg,     0(SPLimitReg)
                 .endmacro
@@ -575,7 +575,7 @@ do_another:     lwzu    r0, size_of_gpr(srcp)
 
 start_exported_function(ContinueNLRFromC)    // called by VM 
                 // pop VM frames
-                import_function_address     Temp1,SaveSelfNonVolRegs_returnPC// get save stub return PC
+                import_function_address(Temp1, SaveSelfNonVolRegs_returnPC) // get save stub return PC
                  b       skipFirstPop
 notFound1:      lwz     sp, LinkageArea_savedSP(sp)     // pop frame
 skipFirstPop:   lwz     r0, LinkageArea_savedPC(sp)
@@ -592,7 +592,7 @@ not_saved1:
                 cmpwi   interp_flag, 0          // interp?
                 beq     cont                   // no, goto compiled variant
 
-                import_data_address Temp1,processSemaphore// clear sema
+                import_data_address(Temp1, processSemaphore) // clear sema
                 li      r0, 0
                 stb     r0, 0(Temp1)
 
@@ -602,20 +602,20 @@ not_saved1:
 cont: 
                 // now load NLR params from globals
 
-                import_data_address     Temp1,NLRResultFromC
+                import_data_address(Temp1, NLRResultFromC)
                 lwz     NLRResultReg, 0(Temp1)
 
-                import_data_address     Temp1,NLRHomeIDFromC
+                import_data_address(Temp1, NLRHomeIDFromC)
                 lwz     NLRHomeIDReg, 0(Temp1)
 
-                import_data_address     Temp1,NLRHomeFromC// These two only needed if going back to self, just do anyway
+                import_data_address(Temp1, NLRHomeFromC) // These two only needed if going back to self, just do anyway
                 lwz     NLRHomeReg, 0(Temp1)        
 
                 lwz     Temp1, LinkageArea_savedPC(sp) // return
                 addi    r0, Temp1, non_local_return_offset
                 mtlr    r0 // return thru inline cache
 
-                import_data_address Temp1,processSemaphore// clear sema
+                import_data_address(Temp1, processSemaphore) // clear sema
                 li      r0, 0
                 stb     r0, 0(Temp1)
 
@@ -639,7 +639,7 @@ cont:
                 start_exported_function(ContinueAfterReturnTrap)
                 // setup NLR regs
     // pop VM frames
-                import_function_address     Temp1,ReturnTrap_returnPC// get save stub return PC
+                import_function_address(Temp1, ReturnTrap_returnPC) // get save stub return PC
                 b       loop_entry_point1
                 
 notFound2:      lwz     r0, LinkageArea_savedPC(sp)
@@ -653,7 +653,7 @@ loop_entry_point1:
                 cmpw    sp, sp_arg
                 bne     notFound2
 
-                import_data_address Temp1,processSemaphore// clear sema
+                import_data_address(Temp1, processSemaphore) // clear sema
                 li      r0, 0
                 stb     r0, 0(Temp1)
                 
@@ -684,7 +684,7 @@ loop_entry_point1:
                 mr      r6, Temp1
                 mr      r7, Temp2
                                         // pop VM frames
-                import_function_address     Temp1,ReturnTrap_returnPC// get save stub return PC
+                import_function_address(Temp1, ReturnTrap_returnPC) // get save stub return PC
                 b       loop_entry_point2
                 
 notFound3:      lwz     r0, LinkageArea_savedPC(sp)
@@ -699,7 +699,7 @@ loop_entry_point2:
                 bne     notFound3
                 
                                 
-                import_data_address Temp1,processSemaphore// clear sema
+                import_data_address(Temp1, processSemaphore) // clear sema
                 li      r0, 0
                 stb     r0, 0(Temp1)
                 
@@ -803,7 +803,7 @@ send_desc_end:
 
 //        continue with NLR: prepare to call capture_NLR_parameters_from_registers with NLR reg params
 
-contNLR:          import_function_address     Temp1,capture_NLR_parameters_from_registers
+contNLR:          import_function_address(Temp1, capture_NLR_parameters_from_registers)
                   mtlr    Temp1
                   
                   // don't need this because they are already in the right registers!
@@ -861,7 +861,7 @@ contNLR:          import_function_address     Temp1,capture_NLR_parameters_from_
                  la     r4, frsize(sp)//  lookup frame
                  mflr   r3// // REUSING LINK VALUE for sendDesc arg
                  
-                 import_function_address    Temp1,SendMessage
+                 import_function_address(Temp1, SendMessage)
                  mtlr   Temp1
                  blrl
                  
@@ -933,7 +933,7 @@ start_exported_function(SendDIMessage_stub)
                  
                  //  ahh... through with DI*Reg's
                
-                 import_function_address    Temp1,SendDIMessage
+                 import_function_address(Temp1, SendDIMessage)
                  mtlr   Temp1
                  blrl
                  
@@ -994,7 +994,7 @@ start_exported_function(MakeOld_stub)
                  stw    r3, LinkageArea_savedPC + frsize(sp)// and save link for stack crawling
                  
                  // will be calling MakeOld, but save non vols on the way
-                 import_function_address    Temp1,MakeOld
+                 import_function_address(Temp1, MakeOld)
                  mtlr   Temp1
                  blrl
                  
@@ -1061,7 +1061,7 @@ ReturnTrap_do_call:
                  // (link must already be saved since this is a return trap -- dmu 2/04)
                  stwu   sp, -ReturnTrap_frame_size(sp)
                  
-import_function_address    Temp1,HandleReturnTrap
+                 import_function_address(Temp1, HandleReturnTrap)
                  mtlr   Temp1
                  blrl
                  
@@ -1128,7 +1128,7 @@ pf2:
                  stswi arg0 /* also normal result reg */,Temp1,  numVolRegsToSave * oopSize
                  mr    arg0, Temp2
                  
-import_function_address    Temp1,HandleProfilerTrap
+                 import_function_address(Temp1, HandleProfilerTrap)
                  mtlr   Temp1
                  blrl
                  
@@ -1214,7 +1214,7 @@ start_exported_function(Recompile_stub)
                  stw    r3, LinkageArea_savedPC + frsize(sp)// and save link for stack crawling
                  
                  // will be calling Recompile, but save non vols on the way
-                 import_function_address    Temp1,Recompile
+                 import_function_address(Temp1, Recompile)
                  mtlr   Temp1
                  blrl
                  

--- a/vm/src/ppc/runtime/runtime_asm_mw_ppc.S
+++ b/vm/src/ppc/runtime/runtime_asm_mw_ppc.S
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 # if 0
 # skip when compiling with gcc
 ; // Sun-$Revision: 30.11 $

--- a/vm/src/ppc/runtime/runtime_ppc.cpp
+++ b/vm/src/ppc/runtime/runtime_ppc.cpp
@@ -110,10 +110,19 @@ void set_flags_for_platform() {
 
 
 # include <sys/sysctl.h>
+# if TARGET_OS_VERSION == NETBSD_VERSION
+#  include <machine/cpu.h>
+# endif
 
 // call haveAltiVec() instead of me
 bool slow_haveAltiVec() {
+#if TARGET_OS_VERSION == MACOSX_VERSION
   int selectors[2] = { CTL_HW, HW_VECTORUNIT };
+#elif TARGET_OS_VERSION == NETBSD_VERSION
+  int selectors[2] = { CTL_MACHDEP, CPU_ALTIVEC };
+#else
+#  error what os?
+#endif
   int hasVectorUnit = 0;
   size_t length = sizeof(hasVectorUnit);
   int error = sysctl(selectors, 2, &hasVectorUnit, &length, NULL, 0);

--- a/vm/src/ppc/runtime/runtime_ppc.hh
+++ b/vm/src/ppc/runtime/runtime_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.17 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/sic/basicNode_ppc.hh
+++ b/vm/src/ppc/sic/basicNode_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.6 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/sic/deadBlockNode_ppc.hh
+++ b/vm/src/ppc/sic/deadBlockNode_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 1.5 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/sic/genHelper_ppc.hh
+++ b/vm/src/ppc/sic/genHelper_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.13 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/sic/longRegString_ppc.hh
+++ b/vm/src/ppc/sic/longRegString_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.6 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/sic/prologueNode_ppc.hh
+++ b/vm/src/ppc/sic/prologueNode_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.6 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/sic/sic_ppc.hh
+++ b/vm/src/ppc/sic/sic_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.9 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/zone/addrDesc_ppc.hh
+++ b/vm/src/ppc/zone/addrDesc_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.9 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/zone/allocZone_ppc.S
+++ b/vm/src/ppc/zone/allocZone_ppc.S
@@ -1,4 +1,4 @@
-# ifdef __ppc__`
+# if defined(__ppc__) || defined(__powerpc__)
 ;/* Sun-$Revision: 30.10 $ */
 
 ;/* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/zone/countPattern_ppc.hh
+++ b/vm/src/ppc/zone/countPattern_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.7 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/zone/countStub_ppc.hh
+++ b/vm/src/ppc/zone/countStub_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.12 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/zone/nmethod_ppc.hh
+++ b/vm/src/ppc/zone/nmethod_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.9 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.

--- a/vm/src/ppc/zone/trapdoors_ppc.hh
+++ b/vm/src/ppc/zone/trapdoors_ppc.hh
@@ -1,4 +1,4 @@
-# ifdef __ppc__
+# if defined(__ppc__) || defined(__powerpc__)
 /* Sun-$Revision: 30.9 $ */
 
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.


### PR DESCRIPTION
This PR does the menial work of bringing back the PowerPC port.  **NB:** It does _not_ work.

The ppc port of Self was targeting only the macs, so it does not work with the ELF ABI that has different call frame layout.

However the PR makes the tree buildable on NetBSD/macppc (and probably very little changes would be required to build on FreeBSD or Linux, if Linux still supports 32-bit ppc, that is).  The PR doesn't affect any i386 code.

I think it's worth merging.  It doesn't make any actually currently runnable code worse, and it brings the ppc code into a better shape, even if still not working.  Should make life easier for someone who might be interested to continue the work on ELF (sup)port.

Unfortunately I don't have a MacOSX/ppc system to test if the code is still buildable there, on its intended target, but I think I was careful enough not to break things (too much).
