### PR TITLE
Fix `#pragma implementation` nits

### DIFF
--- a/vm/src/any/objects/fctProxyOop.cpp
+++ b/vm/src/any/objects/fctProxyOop.cpp
@@ -4,7 +4,7 @@
    See the LICENSE file for license information. */
 
 # pragma implementation "fctProxyOop.hh"
-#include "_fctProxyOop.cpp.incl"
+# include "_fctProxyOop.cpp.incl"
 
 
 

--- a/vm/src/any/objects/processOop.cpp
+++ b/vm/src/any/objects/processOop.cpp
@@ -3,8 +3,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
-
 # pragma implementation "processOop.hh"
 # include "_processOop.cpp.incl"
 

--- a/vm/src/any/objects/proxyOop.cpp
+++ b/vm/src/any/objects/proxyOop.cpp
@@ -4,7 +4,7 @@
    See the LICENSE file for license information. */
 
 # pragma implementation "proxyOop.hh"
-#include "_proxyOop.cpp.incl"
+# include "_proxyOop.cpp.incl"
 
 // Magic number, stored in proxyOop's cObject field, when it is killed.
 // safer to make it smiOop -- dmu

--- a/vm/src/any/os/xlibWindow.cpp
+++ b/vm/src/any/os/xlibWindow.cpp
@@ -3,8 +3,7 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-# pragma implementation
-
+# pragma implementation "xlibWindow.hh"
 # include "_xlibWindow.cpp.incl"
 
 # ifdef XLIB

--- a/vm/src/any/sic/inlining.cpp
+++ b/vm/src/any/sic/inlining.cpp
@@ -3,7 +3,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "inlining.hh"
 # include "_inlining.cpp.incl"
 

--- a/vm/src/any/sic/node.cpp
+++ b/vm/src/any/sic/node.cpp
@@ -3,7 +3,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "node.hh"
 # pragma implementation "node_inline.hh"
 

--- a/vm/src/i386/fast_compiler/fcompiler_i386.cpp
+++ b/vm/src/i386/fast_compiler/fcompiler_i386.cpp
@@ -4,7 +4,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "fcompiler_i386.hh"
 # include "_fcompiler_i386.cpp.incl"
 

--- a/vm/src/i386/sic/sic_i386.cpp
+++ b/vm/src/i386/sic/sic_i386.cpp
@@ -4,7 +4,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "sic_i386.hh"
 # include "_sic_i386.cpp.incl"
 

--- a/vm/src/i386/zone/addrDesc_i386.cpp
+++ b/vm/src/i386/zone/addrDesc_i386.cpp
@@ -4,7 +4,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "addrDesc_i386.hh"
 
 # include "_addrDesc_i386.cpp.incl"

--- a/vm/src/i386/zone/countPattern_i386.cpp
+++ b/vm/src/i386/zone/countPattern_i386.cpp
@@ -4,7 +4,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "countPattern_i386.hh"
 # include "_countPattern_i386.cpp.incl"
 

--- a/vm/src/i386/zone/trapdoors_i386.cpp
+++ b/vm/src/i386/zone/trapdoors_i386.cpp
@@ -4,6 +4,7 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
+# pragma implementation "trapdoors.hh"
 # pragma implementation "trapdoors_i386.hh"
 # include "_trapdoors_i386.cpp.incl"
 

--- a/vm/src/ppc/asm/fields_ppc.cpp
+++ b/vm/src/ppc/asm/fields_ppc.cpp
@@ -4,8 +4,6 @@
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
    See the LICENSE file for license information. */
 
-  
-
 # pragma implementation "fields_ppc.hh"
 
 # include "_fields_ppc.cpp.incl"

--- a/vm/src/ppc/fast_compiler/fcompiler_ppc.cpp
+++ b/vm/src/ppc/fast_compiler/fcompiler_ppc.cpp
@@ -4,7 +4,6 @@
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "fcompiler_ppc.hh"
 # include "_fcompiler_ppc.cpp.incl"
 

--- a/vm/src/ppc/lookup/cacheStub_ppc.cpp
+++ b/vm/src/ppc/lookup/cacheStub_ppc.cpp
@@ -4,7 +4,6 @@
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
    See the LICENSE file for license information. */
 
-  
 # pragma implementation "cacheStub_ppc.hh"
 # pragma implementation "cacheStub_inline_ppc.hh"
 # include "_cacheStub_ppc.cpp.incl"

--- a/vm/src/ppc/sic/sic_ppc.cpp
+++ b/vm/src/ppc/sic/sic_ppc.cpp
@@ -4,7 +4,6 @@
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "sic_ppc.hh"
 # include "_sic_ppc.cpp.incl"
 

--- a/vm/src/ppc/zone/addrDesc_ppc.cpp
+++ b/vm/src/ppc/zone/addrDesc_ppc.cpp
@@ -4,7 +4,6 @@
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "addrDesc_ppc.hh"
 
 # include "_addrDesc_ppc.cpp.incl"

--- a/vm/src/ppc/zone/countPattern_ppc.cpp
+++ b/vm/src/ppc/zone/countPattern_ppc.cpp
@@ -4,7 +4,6 @@
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "countPattern_ppc.hh"
 # include "_countPattern_ppc.cpp.incl"
 

--- a/vm/src/ppc/zone/trapdoors_ppc.cpp
+++ b/vm/src/ppc/zone/trapdoors_ppc.cpp
@@ -4,6 +4,7 @@
 /* Copyright 1992-2006 Sun Microsystems, Inc. and Stanford University.
    See the LICENSE file for license information. */
 
+# pragma implementation "trapdoors.hh"
 # pragma implementation "trapdoors_ppc.hh"
 # include "_trapdoors_ppc.cpp.incl"
 

--- a/vm/src/sparc/asm/opc_sparc.cpp
+++ b/vm/src/sparc/asm/opc_sparc.cpp
@@ -29,7 +29,7 @@ the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.   */
 
 
 # pragma implementation "sparc.hh"
-#include "_opc_sparc.cpp.incl"
+# include "_opc_sparc.cpp.incl"
 
 # if  defined(FAST_COMPILER) || defined(SIC_COMPILER)
 

--- a/vm/src/sparc/asm/pinsn_sparc.cpp
+++ b/vm/src/sparc/asm/pinsn_sparc.cpp
@@ -26,7 +26,7 @@ Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.  */
 
 # pragma implementation "pinsn.hh"
 
-#include "_pinsn_sparc.cpp.incl"
+# include "_pinsn_sparc.cpp.incl"
 
 
 

--- a/vm/src/sparc/lookup/cacheStub_sparc.cpp
+++ b/vm/src/sparc/lookup/cacheStub_sparc.cpp
@@ -2,7 +2,6 @@
 
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
-
   
 # pragma implementation "cacheStub_sparc.hh"
 # pragma implementation "cacheStub_inline_sparc.hh"

--- a/vm/src/sparc/memory/enum_sparc.S
+++ b/vm/src/sparc/memory/enum_sparc.S
@@ -10,7 +10,7 @@
         -- dmu
 */
 
-#include "_enum_sparc.S.incl"
+# include "_enum_sparc.S.incl"
 
 
 .globl find_prior_reference, find_this_object, find_next_object

--- a/vm/src/sparc/prims/asmPrims_sparc.S
+++ b/vm/src/sparc/prims/asmPrims_sparc.S
@@ -6,7 +6,7 @@
 
 ! some integer primitives
 
-#include "_asmPrims_sparc.S.incl"
+# include "_asmPrims_sparc.S.incl"
 
 .global smi_add_prim, smi_sub_prim, smi_mul_prim
 .global smi_complement_prim

--- a/vm/src/sparc/runtime/runtime_asm_gcc_sparc.S
+++ b/vm/src/sparc/runtime/runtime_asm_gcc_sparc.S
@@ -3,7 +3,7 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-#include "_runtime_asm_gcc_sparc.S.incl"
+# include "_runtime_asm_gcc_sparc.S.incl"
 
 // XXX: can't include config.hh here, so FOO_VERSION are not defined
 # if defined(__NetBSD__)	// TARGET_OS_VERSION == NETBSD_VERSION

--- a/vm/src/sparc/sic/node_sparc.cpp
+++ b/vm/src/sparc/sic/node_sparc.cpp
@@ -3,7 +3,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "node_sparc.hh"
 
 # include "_node_sparc.cpp.incl"

--- a/vm/src/sparc/sic/sic_sparc.cpp
+++ b/vm/src/sparc/sic/sic_sparc.cpp
@@ -3,7 +3,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "sic_sparc.hh"
 # include "_sic_sparc.cpp.incl"
 

--- a/vm/src/sparc/zone/addrDesc_sparc.cpp
+++ b/vm/src/sparc/zone/addrDesc_sparc.cpp
@@ -3,7 +3,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "addrDesc_sparc.hh"
 
 # include "_addrDesc_sparc.cpp.incl"

--- a/vm/src/sparc/zone/countPattern_sparc.cpp
+++ b/vm/src/sparc/zone/countPattern_sparc.cpp
@@ -3,7 +3,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # pragma implementation "countPattern_sparc.hh"
 # include "_countPattern_sparc.cpp.incl"
 

--- a/vm/src/sparc/zone/trapdoors_sparc.cpp
+++ b/vm/src/sparc/zone/trapdoors_sparc.cpp
@@ -3,6 +3,7 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
+# pragma implementation "trapdoors.hh"
 # pragma implementation "trapdoors_sparc.hh"
 # include "_trapdoors_sparc.cpp.incl"
 

--- a/vm/src/unix/prims/unixPrims.glue.cpp
+++ b/vm/src/unix/prims/unixPrims.glue.cpp
@@ -5,7 +5,7 @@
 
 # pragma implementation "unixPrims.glue.hh"
 
-#include "_unixPrims.glue.cpp.incl"
+# include "_unixPrims.glue.cpp.incl"
 
 # if  TARGET_OS_VERSION == SOLARIS_VERSION
 extern "C" {

--- a/vm/src/unix/runtime/interruptedCtx_unix.cpp
+++ b/vm/src/unix/runtime/interruptedCtx_unix.cpp
@@ -3,9 +3,8 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-# include "_interruptedCtx_unix.cpp.incl"
-
 # pragma implementation "interruptedCtx_unix.hh"
+# include "_interruptedCtx_unix.cpp.incl"
 
 
 self_sig_context_t InterruptedContext::dummy_scp;

--- a/vm/src/unix/runtime/monitorHooks_unix.cpp
+++ b/vm/src/unix/runtime/monitorHooks_unix.cpp
@@ -3,7 +3,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # include "_monitorHooks_unix.cpp.incl"
 
 

--- a/vm/src/unix/runtime/monitorPieces_unix.cpp
+++ b/vm/src/unix/runtime/monitorPieces_unix.cpp
@@ -3,7 +3,6 @@
 /* Copyright 1992-2012 AUTHORS.
    See the LICENSE file for license information. */
 
-
 # include "_monitorPieces_unix.cpp.incl"
 
  


### PR DESCRIPTION
This PR makes it possible to compile Self with `#pragma interface` and `#pragma implementation` again, reducing amount of object code emitted for inline functions.  I think these changes should be pretty uncontroversial, except may be for the last one that g/c'es some extra blank lines, which might be seen as unnecessary churn.

This PR does _not_ contain any diffs to actually change the way Self is built though.  Those are in a separate PR (#143), as I'm groping around the build system and I'm much less sure about the proposed changes.