### PR TITLE
Enable pragma interface/implementation

### DIFF
--- a/vm/build_support/makeDeps.cpp
+++ b/vm/build_support/makeDeps.cpp
@@ -337,7 +337,8 @@ class LinuxPlatform: public AbstractPlatform {
   // For Unix make, include the dependencies for precompiled header files.
   Bool includeGIDependencies() { return True; }
 
-  Bool includeGIInEachIncl() { return False; }
+  // To make #pragma implementation work with the precompiled headers
+  Bool includeGIInEachIncl() { return True; }
 
   void writeGIInclude(FILE* inclFile ) {
     fprintf(inclFile, "# include \"%s\"\n", GIFileTemplate->pre_stem_suff());
@@ -374,6 +375,13 @@ class UnixPlatform: public AbstractPlatform {
 
   // For Unix make, include the dependencies for precompiled header files.
   Bool includeGIDependencies() { return True; }
+
+  // To make #pragma implementation work with the precompiled headers
+  Bool includeGIInEachIncl() { return True; }
+
+  void writeGIInclude(FILE* inclFile ) {
+    fprintf(inclFile, "# include \"%s\"\n", GIFileTemplate->pre_stem_suff());
+  }
 
 } Plat;
 

--- a/vm/cmake/freebsd.cmake
+++ b/vm/cmake/freebsd.cmake
@@ -57,6 +57,17 @@ endmacro()
 # "API". Setup prefix headers
 #
 macro(include_prefix_header target file)
+  # -include on the command line creates a problem: headers from the
+  # _precompiled.hh are processed before the source file had a chance
+  # to state its #pragma implementation, hence the kludge with the
+  # INTERFACE_PRAGMAS ifdefs in the sources.  Instead makeDeps is now
+  # changed to includeGIInEachIncl so that #pragma's DTRT.  The ifdefs
+  # should probably be disposed of, but for now keep them and supply
+  # the -D instead as a quick, small, low risk change.
+
   # "super"
-  include_prefix_header_common(${target} ${file})
+  # include_prefix_header_common(${target} ${file})
 endmacro()
+
+list(APPEND _defines -DINTERFACE_PRAGMAS)
+list(APPEND _flags   -Winvalid-pch)

--- a/vm/cmake/linux.cmake
+++ b/vm/cmake/linux.cmake
@@ -53,6 +53,17 @@ endmacro()
 # "API". Setup prefix headers
 #
 macro(include_prefix_header target file)
+  # -include on the command line creates a problem: headers from the
+  # _precompiled.hh are processed before the source file had a chance
+  # to state its #pragma implementation, hence the kludge with the
+  # INTERFACE_PRAGMAS ifdefs in the sources.  Instead makeDeps is now
+  # changed to includeGIInEachIncl so that #pragma's DTRT.  The ifdefs
+  # should probably be disposed of, but for now keep them and supply
+  # the -D instead as a quick, small, low risk change.
+
   # "super"
-  include_prefix_header_common(${target} ${file})
+  # include_prefix_header_common(${target} ${file})
 endmacro()
+
+list(APPEND _defines -DINTERFACE_PRAGMAS)
+list(APPEND _flags   -Winvalid-pch)

--- a/vm/cmake/netbsd.cmake
+++ b/vm/cmake/netbsd.cmake
@@ -80,6 +80,17 @@ endmacro()
 # "API". Setup prefix headers
 #
 macro(include_prefix_header target file)
+  # -include on the command line creates a problem: headers from the
+  # _precompiled.hh are processed before the source file had a chance
+  # to state its #pragma implementation, hence the kludge with the
+  # INTERFACE_PRAGMAS ifdefs in the sources.  Instead makeDeps is now
+  # changed to includeGIInEachIncl so that #pragma's DTRT.  The ifdefs
+  # should probably be disposed of, but for now keep them and supply
+  # the -D instead as a quick, small, low risk change.
+
   # "super"
-  include_prefix_header_common(${target} ${file})
+  # include_prefix_header_common(${target} ${file})
 endmacro()
+
+list(APPEND _defines -DINTERFACE_PRAGMAS)
+list(APPEND _flags   -Winvalid-pch)

--- a/vm/cmake/setup.cmake
+++ b/vm/cmake/setup.cmake
@@ -36,11 +36,6 @@ list(APPEND _flags
   -fno-stack-protector
 )
 
-if(gcc)
-  # Flag only supported on GCC
-  list(APPEND _flags -fkeep-inline-functions)
-endif()
-
 if(SELF_COVERAGE)
   list(APPEND _flags --coverage)
 endif()


### PR DESCRIPTION
Fix precompiled header vs. `#pragma implementation` and get rid of `-fkeep-inline-functions`.

This reduces the size of intermediate object files by an order of magnitude and, correspondingly, gives a huge boost to the compilation times.

This change requires PR #142 to be merged first as that PR fixes a couple of problems with the pragmas.  This PR is branched from the same base to make the diff more reviewable as github doesn't do stacked PRs.