### PR TITLE
Do not abuse `strncpy`(3) as `memcpy`(3)

### DIFF
--- a/vm/src/any/memory/universe.more.cpp
+++ b/vm/src/any/memory/universe.more.cpp
@@ -470,9 +470,10 @@ class InterestingMap: public ResourceObj {
 
   InterestingMap(Map* m, const char* n) {
     map = m; count = size = 0;
-    name = NEW_RESOURCE_ARRAY( char, strlen(n));
-    strncpy(name, n, strlen(n));
-    name[strlen(n)-3] = '\0';           // cheap trick to get rid of "Map"
+    const size_t nlen = strlen(n);
+    name = NEW_RESOURCE_ARRAY( char, nlen);
+    memcpy(name, n, nlen);
+    name[nlen-3] = '\0';        // cheap trick to get rid of "Map"
   }
 
   virtual bool matches(oop p, Map* m)   {

--- a/vm/src/any/objects/blockMap.cpp
+++ b/vm/src/any/objects/blockMap.cpp
@@ -23,9 +23,9 @@ blockOop blockMap::create_block(slotsOop meth) {
    default:
     char* slot =  NEW_RESOURCE_ARRAY( char, arg_count * 5 + 2);
     char* s = slot;
-    strncpy(s, "value:With:With:With:With:", 26);
+    memcpy(s, "value:With:With:With:With:", 26);
     for (s += 26, arg_count -= 5; arg_count > 0; arg_count --, s += 5) {
-      strncpy(s, "With:", 5);
+      memcpy(s, "With:", 5);
     }
     *s = '\0';
     name= new_string(slot);

--- a/vm/src/any/objects/stringMap.cpp
+++ b/vm/src/any/objects/stringMap.cpp
@@ -56,15 +56,10 @@ bool stringMap::verify(oop obj) {
 }
 
 void stringMap::print_string(oop obj, char* buf) {
-  /* sprintf breaks (why?)
-  sprintf(buf, "'%*s'", 
-          stringOop(obj)->length(), 
-          stringOop(obj)->bytes());
-  */
   buf[0] = '\'';
   fint n = stringOop(obj)->length();
   n = min(n, BUFSIZ - 3);
-  strncpy(buf + 1, stringOop(obj)->bytes(), n);
+  memcpy(buf + 1, stringOop(obj)->bytes(), n);
   buf[ 1 + n ] = '\'';
   buf[ 2 + n ] = '\0';
 }

--- a/vm/src/any/os/os.cpp
+++ b/vm/src/any/os/os.cpp
@@ -62,17 +62,18 @@ bool OS::expand_user_name(const char* in, const char* slash, char*& dirName) {
   // return false on error
 
   char user[logname_max+1];
-  if (slash  -  (in + 1)  >= sizeof(user)) {
+  const size_t ulen = slash - (in + 1);
+  if (ulen >= sizeof(user)) {
     static char err[max_path_length + 50];
     static char buf[max_path_length + 50];
-    lsprintf_string(buf, slash - (in + 1), in + 1);
+    lsprintf_string(buf, ulen, in + 1);
     sprintf(err, "'%s' exceeds %ld in length",
             buf,  long(sizeof(user) - 1));
     dirName = err;
     return false;
   }
-  strncpy(user, in + 1,  slash - (in + 1));
-  user[slash - (in + 1)] = '\0';
+  memcpy(user, in + 1, ulen);
+  user[ulen] = '\0';
   dirName = get_user_directory(user);
   if (dirName == NULL) {
     static char err[max_path_length + 50];


### PR DESCRIPTION
`strncpy`(3) is abused to copy char data that are not zero-terminated with the length argument computed based on the source data, not the destination buffer.  `strncpy`(3) is really (ab)used here as `memcpy`(3) and the code doesn't even take advantage of the zero-filling behavior of `strncpy` and adds the zero byte manually where it's needed.

Gcc complained about some of these, so fix all of them in a preemptive move.  While here, do CSE on the length calculation where applicable. 