### PR TITLE
asmPrims_sparc.S: work around broken v8 .mul stub on NetBSD

### DIFF
--- a/vm/src/sparc/prims/asmPrims_sparc.S
+++ b/vm/src/sparc/prims/asmPrims_sparc.S
@@ -55,9 +55,16 @@ ok1:    beq,a   ok2
         save    %sp, (16 + 8) * -4, %sp
         ba      handleError
         mov     badTypeOffset, arg1
-ok2:    mov     ireceiver, receiver
+ok2:
+#if __sparc_v8__ || __sparc_v9__
+        sra     iarg1, Tag_Size, arg1
+        smul    ireceiver, %o1, %o0
+        rd      %y, %o1         /* like .mul */
+#else
+        mov     ireceiver, receiver
         call    .Lmul           /* NB: local copy below */
         sra     iarg1, Tag_Size, arg1
+#endif
         sethi   %hi(0x80000000), %g1
         andcc   %o0, %g1, %g0      /* test sign bit of lower part of result */
         beq,a   upper
@@ -153,7 +160,7 @@ breakpoint_prim:
         ret
         restore
 
-
+#if !__sparc_v8__ && !__sparc_v9__
 /*
  * FIXME: NetBSD v8 .mul stub in lib/libarch/sparc/v8/sparc_v8.S
  * doesn't follow .mul ABI.  .mul returns the upper half in %o1, but
@@ -269,3 +276,4 @@ breakpoint_prim:
 	or	%o5, %o0, %o0	! construct low part of result
 	retl
 	sra	%o4, 20, %o1	! ... and extract high part of result
+#endif /* !__sparc_v8__ && !__sparc_v9__ */

--- a/vm/src/sparc/prims/asmPrims_sparc.S
+++ b/vm/src/sparc/prims/asmPrims_sparc.S
@@ -56,7 +56,7 @@ ok1:    beq,a   ok2
         ba      handleError
         mov     badTypeOffset, arg1
 ok2:    mov     ireceiver, receiver
-        call    .mul
+        call    .Lmul           /* NB: local copy below */
         sra     iarg1, Tag_Size, arg1
         sethi   %hi(0x80000000), %g1
         andcc   %o0, %g1, %g0      /* test sign bit of lower part of result */
@@ -152,3 +152,120 @@ breakpoint_prim:
         mov     %i0, %o0
         ret
         restore
+
+
+/*
+ * FIXME: NetBSD v8 .mul stub in lib/libarch/sparc/v8/sparc_v8.S
+ * doesn't follow .mul ABI.  .mul returns the upper half in %o1, but
+ * the real smul instruction (in the v8 stub) returns it in %y.
+ *
+ * Copy .mul from common/lib/libc/arch/sparc/gen/mul.S here:
+ *
+ * Signed multiply, from Appendix E of the Sparc Version 8
+ * Architecture Manual.
+ *
+ * Returns %o0 * %o1 in %o1%o0 (i.e., %o1 holds the upper 32 bits of
+ * the 64-bit product).
+ *
+ * This code optimizes short (less than 13-bit) multiplies.
+ */
+.Lmul:
+	mov	%o0, %y		! multiplier -> Y
+	andncc	%o0, 0xfff, %g0	! test bits 12..31
+	be	.Lmul_shortway	! if zero, can do it the short way
+	andcc	%g0, %g0, %o4	! zero the partial product and clear N and V
+
+	/*
+	 * Long multiply.  32 steps, followed by a final shift step.
+	 */
+	mulscc	%o4, %o1, %o4	! 1
+	mulscc	%o4, %o1, %o4	! 2
+	mulscc	%o4, %o1, %o4	! 3
+	mulscc	%o4, %o1, %o4	! 4
+	mulscc	%o4, %o1, %o4	! 5
+	mulscc	%o4, %o1, %o4	! 6
+	mulscc	%o4, %o1, %o4	! 7
+	mulscc	%o4, %o1, %o4	! 8
+	mulscc	%o4, %o1, %o4	! 9
+	mulscc	%o4, %o1, %o4	! 10
+	mulscc	%o4, %o1, %o4	! 11
+	mulscc	%o4, %o1, %o4	! 12
+	mulscc	%o4, %o1, %o4	! 13
+	mulscc	%o4, %o1, %o4	! 14
+	mulscc	%o4, %o1, %o4	! 15
+	mulscc	%o4, %o1, %o4	! 16
+	mulscc	%o4, %o1, %o4	! 17
+	mulscc	%o4, %o1, %o4	! 18
+	mulscc	%o4, %o1, %o4	! 19
+	mulscc	%o4, %o1, %o4	! 20
+	mulscc	%o4, %o1, %o4	! 21
+	mulscc	%o4, %o1, %o4	! 22
+	mulscc	%o4, %o1, %o4	! 23
+	mulscc	%o4, %o1, %o4	! 24
+	mulscc	%o4, %o1, %o4	! 25
+	mulscc	%o4, %o1, %o4	! 26
+	mulscc	%o4, %o1, %o4	! 27
+	mulscc	%o4, %o1, %o4	! 28
+	mulscc	%o4, %o1, %o4	! 29
+	mulscc	%o4, %o1, %o4	! 30
+	mulscc	%o4, %o1, %o4	! 31
+	mulscc	%o4, %o1, %o4	! 32
+	mulscc	%o4, %g0, %o4	! final shift
+
+	! If %o0 was negative, the result is
+	!	(%o0 * %o1) + (%o1 << 32))
+	! We fix that here.
+
+	tst	%o0
+	bge	1f
+	rd	%y, %o0
+
+	! %o0 was indeed negative; fix upper 32 bits of result by subtracting 
+	! %o1 (i.e., return %o4 - %o1 in %o1).
+	retl
+	sub	%o4, %o1, %o1
+
+1:
+	retl
+	mov	%o4, %o1
+
+.Lmul_shortway:
+	/*
+	 * Short multiply.  12 steps, followed by a final shift step.
+	 * The resulting bits are off by 12 and (32-12) = 20 bit positions,
+	 * but there is no problem with %o0 being negative (unlike above).
+	 */
+	mulscc	%o4, %o1, %o4	! 1
+	mulscc	%o4, %o1, %o4	! 2
+	mulscc	%o4, %o1, %o4	! 3
+	mulscc	%o4, %o1, %o4	! 4
+	mulscc	%o4, %o1, %o4	! 5
+	mulscc	%o4, %o1, %o4	! 6
+	mulscc	%o4, %o1, %o4	! 7
+	mulscc	%o4, %o1, %o4	! 8
+	mulscc	%o4, %o1, %o4	! 9
+	mulscc	%o4, %o1, %o4	! 10
+	mulscc	%o4, %o1, %o4	! 11
+	mulscc	%o4, %o1, %o4	! 12
+	mulscc	%o4, %g0, %o4	! final shift
+
+	/*
+	 *  %o4 has 20 of the bits that should be in the low part of the
+	 * result; %y has the bottom 12 (as %y's top 12).  That is:
+	 *
+	 *	  %o4		    %y
+	 * +----------------+----------------+
+	 * | -12- |   -20-  | -12- |   -20-  |
+	 * +------(---------+------)---------+
+	 *  --hi-- ----low-part----
+	 *
+	 * The upper 12 bits of %o4 should be sign-extended to form the
+	 * high part of the product (i.e., highpart = %o4 >> 20).
+	 */
+
+	rd	%y, %o5
+	sll	%o4, 12, %o0	! shift middle bits left 12
+	srl	%o5, 20, %o5	! shift low bits right 20, zero fill at left
+	or	%o5, %o0, %o0	! construct low part of result
+	retl
+	sra	%o4, 20, %o1	! ... and extract high part of result


### PR DESCRIPTION
Sparc v7 has no multiplication instruction so a .mul function is used to do the multiplication.  Typically dynamic linker detects v8 and interposes a DSO where .mul is implemented using the v8 multiplication instruction.

Unfortunately the NetBSD .mul stub doesn't follow the ABI. .mul is defined to return the upper bits in %o1, but smul instruction returns it in %y.  Nothing in the gcc generated code uses the upper half, but Self does and garbage in %o1 makes it think multiplication failed.

As a quick kludge provide and always use a local copy of .mul that behaves as expected.

Works around #152.