### PR TITLE
Fix `lookup` signature in Message Lookup Semantics

### DIFF
--- a/docs/handbook/langref.rst
+++ b/docs/handbook/langref.rst
@@ -752,7 +752,7 @@ The message sending semantics are decomposed into the following functions:
 	+--------------------------+-----------------------------------------------------------------------------------------+
 	| send(rec, sel, args)     | The message send function (:ref:`pp-mesage-send`).                                      |
 	+--------------------------+-----------------------------------------------------------------------------------------+
-	| lookup(obj, rec, sel, V) | The lookup algorithm (:ref:`pp-lookup-algorithm`).                                      |
+	| lookup(obj, sel, V) | The lookup algorithm (:ref:`pp-lookup-algorithm`).                                      |
 	+--------------------------+-----------------------------------------------------------------------------------------+
 	| undirected_resend(...)   | The undirected message resend function (:ref:`pp-undirected-resend`).                   |
 	+--------------------------+-----------------------------------------------------------------------------------------+


### PR DESCRIPTION
I think the signature as given involves the subject of the lookup twice, in both the `rec` and `obj` formal arguments.

Because `lookup` is not applied to the original receiver only, I have chosen to keep `obj`. This is coherent with subsequent mentions of `lookup`