### PR TITLE
Fix one-byte heap overread in copy_string

### DIFF
--- a/vm/src/any/runtime/util.cpp
+++ b/vm/src/any/runtime/util.cpp
@@ -68,7 +68,7 @@ char* copy_c_heap_string(const char* s) {
 
 char* copy_string(const char* s, smi len) {
   char* str = NEW_RESOURCE_ARRAY( char, len+1);
-  memcpy(str, s, len+1);
+  memcpy(str, s, len);
   str[len] = '\0';
   return str;
 }

--- a/vm64/src/any/runtime/util.cpp
+++ b/vm64/src/any/runtime/util.cpp
@@ -68,7 +68,7 @@ char* copy_c_heap_string(const char* s) {
 
 char* copy_string(const char* s, smi len) {
   char* str = NEW_RESOURCE_ARRAY( char, len+1);
-  memcpy(str, s, len+1);
+  memcpy(str, s, len);
   str[len] = '\0';
   return str;
 }


### PR DESCRIPTION
## Summary

- Fix `copy_string(s, len)` reading one byte past the source buffer via `memcpy(str, s, len+1)`. The next line already writes the null terminator (`str[len] = '\0'`), making the extra byte both redundant and unsafe.
- On the 64-bit VM (aarch64 macOS), this causes a SIGSEGV when a byte vector ends exactly at a heap page boundary — `memmove` reads into the guard page. The crash manifests during Quartz GUI drawing (`desktop open`).
- Fix applied to both `vm/` and `vm64/` copies of `util.cpp`.

## Crash details

```
Signal: SIGSEGV (code 2 = SEGV_ACCERR: invalid permissions for mapped object)
Activity: GUI drawing in progress, 0 window(s) open
Faulting address 0x8041d8000: in old generation (exact end of old0 bytes region)
PC: _platform_memmove + 0x1bc (libsystem_platform.dylib)
LR: copy_string + 120 (Self)
```

## Root cause

The `memcpy(str, s, len+1)` followed by `str[len] = '\0'` is the standard C idiom for copying a null-terminated string by known length — you copy `len` characters plus the existing null terminator (clang-tidy's [`bugprone-not-null-terminated-result`](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/not-null-terminated-result.html) check actually warns when the `+1` is missing). So the original Sun author's intent was almost certainly: "`s` is a C string of length `len`, copy all `len+1` bytes including the terminator." The `str[len] = '\0'` was belt-and-suspenders safety.

**The problem is the callers don't match that assumption:**

1. **`byteVectorOop.cpp:189`** — `copy_string(bytes(), length())`: Self byte vectors are **not** null-terminated. `bytes()` has exactly `length()` bytes of data. There is no null at position `len`. The `+1` reads one byte past the buffer.

2. **`scanner.cpp:854`** — `copy_string(buffer, b-buffer)`: The scanner sets `b[-1] = '\0'` before calling, so the buffer is null-terminated, but the length passed (`b-buffer`) includes that null. So `memcpy(str, buffer, b-buffer+1)` reads one byte past the null — into the scanner's stack buffer (safe in practice, but still unnecessary).

The `len+1` dates back to the initial 4.3 CVS commit (Sun Microsystems, ~1990s). On the 32-bit VM it was benign because byte vectors had word-aligned padding (1–3 extra bytes after data). On the 64-bit VM with 16KB pages, a byte vector's data can end exactly at a page boundary with no padding before the guard page.

**Edge case — `len = 0`:** `memcpy(str, s, 0)` is defined behavior per the C standard (copies nothing). `str[0] = '\0'` then creates an empty string. The old code would `memcpy(str, s, 1)`, reading one byte from `s` then immediately overwriting it — pointless and potentially dangerous for a zero-length byte vector.

## Test plan

- [x] VM C++ unit tests pass (25/25)
- [x] World build succeeds (`worldBuilder.self -o morphic`)
- [x] Self-level automatic tests pass (0 errors)
- [x] `desktop open` no longer crashes (previously SIGSEGV on every attempt)

Tested on: macOS 15.5, Apple Silicon (arm64), Clang 16, CMake 3.31.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)